### PR TITLE
Support for test durations in testFinished messages

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -26,8 +26,11 @@ class TeamcityServiceMessages(object):
     def testStarted(self, testName):
         self.message('testStarted', name=testName)
 
-    def testFinished(self, testName):
-        self.message('testFinished', name=testName)
+    def testFinished(self, testName, testDuration=None):
+        if testDuration:
+            self.message('testFinished', name=testName, duration=testDuration)
+        else:
+            self.message('testFinished', name=testName)
 
     def testIgnored(self, testName, message=''):
         self.message('testIgnored', name=testName, message=message)

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -2,6 +2,7 @@
 import traceback
 import sys
 from unittest import TestResult
+import datetime
 
 from teamcity.messages import TeamcityServiceMessages
 
@@ -12,6 +13,7 @@ class TeamcityTestResult(TestResult):
         TestResult.__init__(self)
 
         self.output = stream
+        self.test_started = None
 
         self.createMessages()
 
@@ -47,10 +49,13 @@ class TeamcityTestResult(TestResult):
                                  message='Failure', details=err)
 
     def startTest(self, test):
+        self.test_started = datetime.datetime.now()
         self.messages.testStarted(self.getTestName(test))
 
     def stopTest(self, test):
-        self.messages.testFinished(self.getTestName(test))
+        dt = datetime.datetime.now() - self.test_started
+        test_duration = str(int(dt.total_seconds() * 1000))
+        self.messages.testFinished(self.getTestName(test), test_duration)
 
 
 class TeamcityTestRunner(object):

--- a/test/test-unittest.output.gold
+++ b/test/test-unittest.output.gold
@@ -3,33 +3,33 @@
 
 ##teamcity[testFailed details='TRACEBACK' message='Failure' name='testAssert (__main__.TestTeamcityMessages)']
 
-##teamcity[testFinished name='testAssert (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testAssert (__main__.TestTeamcityMessages)']
 
 ##teamcity[testStarted name='testAssertEqual (__main__.TestTeamcityMessages)']
 
 ##teamcity[testFailed details='TRACEBACK' message='Failure' name='testAssertEqual (__main__.TestTeamcityMessages)']
 
-##teamcity[testFinished name='testAssertEqual (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testAssertEqual (__main__.TestTeamcityMessages)']
 
 ##teamcity[testStarted name='testAssertEqualMsg (__main__.TestTeamcityMessages)']
 
 ##teamcity[testFailed details='TRACEBACK' message='Failure' name='testAssertEqualMsg (__main__.TestTeamcityMessages)']
 
-##teamcity[testFinished name='testAssertEqualMsg (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testAssertEqualMsg (__main__.TestTeamcityMessages)']
 
 ##teamcity[testStarted name='testException (__main__.TestTeamcityMessages)']
 
 ##teamcity[testFailed details='TRACEBACK' message='Error' name='testException (__main__.TestTeamcityMessages)']
 
-##teamcity[testFinished name='testException (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testException (__main__.TestTeamcityMessages)']
 
 ##teamcity[testStarted name='testFail (__main__.TestTeamcityMessages)']
 
 ##teamcity[testFailed details='TRACEBACK' message='Failure' name='testFail (__main__.TestTeamcityMessages)']
 
-##teamcity[testFinished name='testFail (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testFail (__main__.TestTeamcityMessages)']
 
 ##teamcity[testStarted name='testPass (__main__.TestTeamcityMessages)']
 ok
 
-##teamcity[testFinished name='testPass (__main__.TestTeamcityMessages)']
+##teamcity[testFinished duration='0' name='testPass (__main__.TestTeamcityMessages)']


### PR DESCRIPTION
Added support for `duration` key for `unittest` python module. TeamCity supports this key to set durations manually.

This can be useful in some scenarios when tests are run on remote machine and TeamCity build agent only translates results to stdout. I have exactly this setup and in this case TeamCity is unable to correctly calculate test durations by itself.
