### PR TITLE
Add support for skipped tests

### DIFF
--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -72,6 +72,17 @@ class TeamcityTestResult(TestResult):
         self.messages.testFailed(self.getTestName(test),
                                  message='Failure', details=err)
 
+    def addSkip(self, test, reason):
+        TestResult.addSkip(self, test, reason)
+        
+        if self.getTestName(test) != self.test_name:
+            sys.stderr.write("INTERNAL ERROR: addSkip(%s) outside of test\n" % self.getTestName(test))
+            sys.stderr.write("Reason: %s\n" % reason)
+            return
+            
+        ##teamcity[testIgnored name='<testname>' message='<reason>']
+        self.messages.testIgnored(self.getTestName(test), reason)
+
     def startTest(self, test):
         self.test_started_datetime = datetime.datetime.now()
         self.test_name = self.getTestName(test)

--- a/test/test-unittest.output.gold
+++ b/test/test-unittest.output.gold
@@ -48,3 +48,9 @@ ok
 ok
 
 ##teamcity[testFinished timestamp='TIMESTAMP' duration='MS' name='testPass (__main__.TestTeamcityMessages)']
+
+##teamcity[testStarted timestamp='TIMESTAMP' name='testSkipped (__main__.TestTeamcityMessages)']
+
+##teamcity[testIgnored timestamp='TIMESTAMP' message='Reason for skipping' name='testSkipped (__main__.TestTeamcityMessages)']
+
+##teamcity[testFinished timestamp='TIMESTAMP' duration='MS' name='testSkipped (__main__.TestTeamcityMessages)']

--- a/test/test-unittest.py
+++ b/test/test-unittest.py
@@ -2,6 +2,7 @@
 from teamcity.unittestpy import TeamcityTestRunner
 from teamcity.messages import TeamcityServiceMessages
 import unittest
+import sys
 from datetime import datetime
 
 
@@ -23,6 +24,13 @@ class TestTeamcityMessages(unittest.TestCase):
 
     def testException(self):
         raise Exception("some exception")
+    
+    if sys.version_info >= (2,7):  
+        # test skipping markup is only available since python 2.7  
+        # http://docs.python.org/2/library/unittest.html#skipping-tests-and-expected-failures
+        @unittest.skip("Reason for skipping")
+        def testSkipped(self):
+            self.fail("This should not appear")
 
 
 class StreamStub(object):


### PR DESCRIPTION
Currently, tests which are skipped (using @unittest.skip) appear as passing on TeamCity, which is confusing.

This change makes skipped tests appear as "ignored" on TeamCity.

Note that this pull request is revamping part of a previous pull-request (https://github.com/JetBrains/teamcity-python/pull/8) and adding a test too.
