### PR TITLE
Use absolute import for 'django'

### DIFF
--- a/teamcity/django.py
+++ b/teamcity/django.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.test.runner import DiscoverRunner
 from teamcity.unittestpy import TeamcityTestRunner
 


### PR DESCRIPTION
Avoids importing same file (teamcity/django.py) instead of the real
django. Only necessary for python 2.

See #31. Cheers.
