### PR TITLE
Bugfix incorrect class in super call

### DIFF
--- a/teamcity/nose_report.py
+++ b/teamcity/nose_report.py
@@ -11,7 +11,7 @@ class TeamcityReport(TeamcityTestResult):
     score = 2
 
     def __init__(self):
-        super(TeamcityTestResult, self).__init__()
+        super(TeamcityReport, self).__init__()
 
     def configure(self, options, conf):
         self.enabled = is_running_under_teamcity()


### PR DESCRIPTION
In the call to super function the current class should be passed, instead of the parent class.
