### PR TITLE
Add twisted framework plugin for trial support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,15 @@ Issue Tracker: https://github.com/JetBrains/teamcity-messages/issues
     url="https://github.com/JetBrains/teamcity-messages",
     platforms=["any"],
 
-    packages=["teamcity"],
-
+    packages=["teamcity", "twisted.plugins"],
+    zip_safe=False,
+    package_data={
+        'twisted': ['plugins/teamcity_plugin.py'],
+    },
+    
     tests_require=['pytest', 'virtualenv'],
     cmdclass={'test': PyTest},
-
+    
     entry_points={
         'nose.plugins.0.10': [
             'teamcity-report = teamcity.nose_report:TeamcityReport'
@@ -81,3 +85,9 @@ Issue Tracker: https://github.com/JetBrains/teamcity-messages/issues
         ]
     },
 )
+
+try:
+    from twisted.plugin import IPlugin, getPlugins
+    list(getPlugins(IPlugin))
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,10 @@ Issue Tracker: https://github.com/JetBrains/teamcity-messages/issues
     package_data={
         'twisted': ['plugins/teamcity_plugin.py'],
     },
-    
+
     tests_require=['pytest', 'virtualenv'],
     cmdclass={'test': PyTest},
-    
+
     entry_points={
         'nose.plugins.0.10': [
             'teamcity-report = teamcity.nose_report:TeamcityReport'

--- a/twisted/plugins/teamcity_plugin.py
+++ b/twisted/plugins/teamcity_plugin.py
@@ -1,0 +1,24 @@
+import sys
+from teamcity.unittestpy import TeamcityTestResult
+from zope.interface import implementer, implements
+from twisted.trial import itrial
+from twisted.trial.reporter import Reporter
+from teamcity.messages import TeamcityServiceMessages
+from twisted.trial.itrial import IReporter
+from twisted.plugin import IPlugin
+from twisted.plugins.twisted_trial import _Reporter
+
+class TeamcityReporter(TeamcityTestResult, Reporter):
+
+    def __init__(self, stream=sys.stdout, tbformat='default', realtime=False,
+                 publisher=None):
+        TeamcityTestResult.__init__(self)
+        Reporter.__init__(self, stream=stream, tbformat=tbformat,
+                realtime=realtime, publisher=publisher)
+
+Teamcity = _Reporter("Teamcity Reporter",
+                 "twisted.plugins.teamcity_plugin",
+                 description="teamcity messages",
+                 longOpt="teamcity",
+                 shortOpt="teamcity",
+                 klass="TeamcityReporter")

--- a/twisted/plugins/teamcity_plugin.py
+++ b/twisted/plugins/teamcity_plugin.py
@@ -1,24 +1,26 @@
 import sys
 from teamcity.unittestpy import TeamcityTestResult
-from zope.interface import implementer, implements
-from twisted.trial import itrial
 from twisted.trial.reporter import Reporter
-from teamcity.messages import TeamcityServiceMessages
-from twisted.trial.itrial import IReporter
-from twisted.plugin import IPlugin
 from twisted.plugins.twisted_trial import _Reporter
+
 
 class TeamcityReporter(TeamcityTestResult, Reporter):
 
-    def __init__(self, stream=sys.stdout, tbformat='default', realtime=False,
+    def __init__(self,
+                 stream=sys.stdout,
+                 tbformat='default',
+                 realtime=False,
                  publisher=None):
         TeamcityTestResult.__init__(self)
-        Reporter.__init__(self, stream=stream, tbformat=tbformat,
-                realtime=realtime, publisher=publisher)
+        Reporter.__init__(self,
+                          stream=stream,
+                          tbformat=tbformat,
+                          realtime=realtime,
+                          publisher=publisher)
 
 Teamcity = _Reporter("Teamcity Reporter",
-                 "twisted.plugins.teamcity_plugin",
-                 description="teamcity messages",
-                 longOpt="teamcity",
-                 shortOpt="teamcity",
-                 klass="TeamcityReporter")
+                     "twisted.plugins.teamcity_plugin",
+                     description="teamcity messages",
+                     longOpt="teamcity",
+                     shortOpt="teamcity",
+                     klass="TeamcityReporter")


### PR DESCRIPTION
This commit allows to run trial script with teamcity reporter option e.g:
```bash
trial --reporter=teamcity tests.py
```
zip_safe=False prevent twisted.plugin dropin.cache from fail on updating inside egg zip (don't know how to fix it else)
```bash
trial --help-reporters
Trial's output can be customized using plugins called Reporters. You can
select any of the following reporters using --reporter=<foo>

ZipPath('/Library/Python/2.7/site-packages/teamcity_messages-1.14-py2.7.egg/twisted/plugins/dropin.cache')
Unexpected error while writing cache file
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/Twisted-15.1.0-py2.7-macosx-10.10-intel.egg/twisted/python/usage.py", line 255, in parseOptions
    self._dispatch[optMangled](optMangled, arg)
  File "/Library/Python/2.7/site-packages/Twisted-15.1.0-py2.7-macosx-10.10-intel.egg/twisted/python/usage.py", line 415, in <lambda>
    fn = lambda name, value=None, m=method: m()
  File "/Library/Python/2.7/site-packages/Twisted-15.1.0-py2.7-macosx-10.10-intel.egg/twisted/scripts/trial.py", line 299, in opt_help_reporters
    for p in plugin.getPlugins(itrial.IReporter):
  File "/Library/Python/2.7/site-packages/Twisted-15.1.0-py2.7-macosx-10.10-intel.egg/twisted/plugin.py", line 210, in getPlugins
    allDropins = getCache(package)
--- <exception caught here> ---
  File "/Library/Python/2.7/site-packages/Twisted-15.1.0-py2.7-macosx-10.10-intel.egg/twisted/plugin.py", line 182, in getCache
    dropinPath.setContent(pickle.dumps(dropinDotCache))
exceptions.AttributeError: 'ZipPath' object has no attribute 'setContent'
```