### PR TITLE
making a patch fix for the testfinished bug

### DIFF
--- a/teamcity/nose_report.py
+++ b/teamcity/nose_report.py
@@ -128,7 +128,7 @@ class TeamcityReport(object):
         self.test_started_datetime_map[test_id] = datetime.datetime.now()
         self.messages.testStarted(test_id, captureStandardOutput='true', flowId=test_id)
 
-    def stopTest(self, test):
+    def addSuccess(self, test):
         test_id = self.get_test_id(test)
 
         time_diff = datetime.datetime.now() - self.test_started_datetime_map[test_id]


### PR DESCRIPTION
Possible fix for an error concerning the fact that nosetests calls "testfinished," on failed tests.

This should break a bunch of tests.