### PR TITLE
Implement support for blocks

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -10,6 +10,32 @@ else:
     text_type = str
 
 
+class BlockContextManager(object):
+    """Context manager for logging blockOpened and blockClosed."""
+    def __init__(self, name, messages):
+        self.name = name
+        self.messages = messages
+        self.closed = False
+
+    def __enter__(self):
+        self.message('blockOpened', name=self.name)
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        # Prevent emitting blockClosed message twice
+        if self.closed:
+            return
+
+        self.message('blockClosed', name=self.name)
+        self.closed = True
+
+    def message(self, *args, **kwargs):
+        return self.messages.message(*args, **kwargs)
+
+
 class TeamcityServiceMessages(object):
     quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
 
@@ -100,3 +126,6 @@ class TeamcityServiceMessages(object):
 
     def customMessage(self, text, status, errorDetails='', flowId=None):
         self.message('message', text=text, status=status, errorDetails=errorDetails, flowId=flowId)
+
+    def block(self, name):
+        return BlockContextManager(name=name, messages=self)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -51,6 +51,22 @@ def test_three_properties():
     assert stream.observed_output == "\n##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple' meat='steak' pie='raspberry']\n".encode('utf-8')
 
 
+def test_blocks():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.block("Doing something that's important"):
+        messages.message("Doing stuff")
+    expected_output = textwrap.dedent("""
+        ##teamcity[blockOpened timestamp='2000-11-02T10:23:01.556' name='Doing something that|'s important']
+
+        ##teamcity[Doing stuff timestamp='2000-11-02T10:23:01.556']
+
+        ##teamcity[blockClosed timestamp='2000-11-02T10:23:01.556' name='Doing something that|'s important']
+        """)
+    expected_output = expected_output.encode('utf-8')
+    assert stream.observed_output == expected_output
+
+
 def test_unicode():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)


### PR DESCRIPTION
Implement blocks as described at https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-BlocksofServiceMessages

```
$ tox
...
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy3: commands succeeded
  congratulations :)
```

Cc: @shalupov, @sudarkoff, @aconrad, @djeebus 