### PR TITLE
More context managers

### DIFF
--- a/teamcity/context_managers.py
+++ b/teamcity/context_managers.py
@@ -1,0 +1,53 @@
+try:
+    from contextlib2 import contextmanager
+except:
+    from contextlib import contextmanager
+
+
+@contextmanager
+def block(messages, name, flowId=None):
+    messages.blockOpened(name, flowId)
+    yield
+    messages.blockClosed(name, flowId)
+
+
+@contextmanager
+def compilation(messages, compiler):
+    messages.compilationStarted(compiler)
+    yield
+    messages.compilationFinished(compiler)
+
+
+@contextmanager
+def testSuite(messages, name):
+    messages.testSuiteStarted(name)
+    yield
+    messages.testSuiteFinished(name)
+
+
+@contextmanager
+def test(messages, testName, captureStandardOutput=None, flowId=None, testDuration=None):
+    messages.testStarted(testName=testName, captureStandardOutput=captureStandardOutput, flowId=flowId)
+    yield
+    messages.testFinished(testName=testName, testDuration=testDuration, flowId=flowId)
+
+
+@contextmanager
+def progress(messages, message):
+    messages.progressStart(message)
+    yield
+    messages.progressFinish(message)
+
+
+@contextmanager
+def serviceMessagesDisabled(messages, flowId=None):
+    messages.disableServiceMessages(flowId=flowId)
+    yield
+    messages.enableServiceMessages(flowId=flowId)
+
+
+@contextmanager
+def serviceMessagesEnabled(messages, flowId=None):
+    messages.enableServiceMessages(flowId=flowId)
+    yield
+    messages.disableServiceMessages(flowId=flowId)

--- a/tests/unit-tests-since-2.6/messages26_test.py
+++ b/tests/unit-tests-since-2.6/messages26_test.py
@@ -46,3 +46,75 @@ def test_blocks_with_flowid():
         """)
     expected_output = expected_output.encode('utf-8')
     assert stream.observed_output == expected_output
+
+
+def test_compilation():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.compilation('gcc'):
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[compilationStarted timestamp='2000-11-02T10:23:01.556' compiler='gcc']
+
+        ##teamcity[compilationFinished timestamp='2000-11-02T10:23:01.556' compiler='gcc']
+        """).strip().encode('utf-8')
+
+
+def test_test_suite():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.testSuite('suite emotion'):
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testSuiteStarted timestamp='2000-11-02T10:23:01.556' name='suite emotion']
+
+        ##teamcity[testSuiteFinished timestamp='2000-11-02T10:23:01.556' name='suite emotion']
+        """).strip().encode('utf-8')
+
+
+def test_test():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.test('only a test'):
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testStarted timestamp='2000-11-02T10:23:01.556' name='only a test']
+
+        ##teamcity[testFinished timestamp='2000-11-02T10:23:01.556' name='only a test']
+        """).strip().encode('utf-8')
+
+
+def test_progress():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.progress('only a test'):
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[progressStart 'only a test']
+
+        ##teamcity[progressFinish 'only a test']
+        """).strip().encode('utf-8')
+
+
+def test_service_messages_disabled():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.serviceMessagesDisabled():
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[disableServiceMessages timestamp='2000-11-02T10:23:01.556']
+
+        ##teamcity[enableServiceMessages timestamp='2000-11-02T10:23:01.556']
+        """).strip().encode('utf-8')
+
+
+def test_service_messages_enabled():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    with messages.serviceMessagesEnabled():
+        pass
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[enableServiceMessages timestamp='2000-11-02T10:23:01.556']
+
+        ##teamcity[disableServiceMessages timestamp='2000-11-02T10:23:01.556']
+        """).strip().encode('utf-8')

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -70,6 +70,222 @@ def test_progress_message_unicode():
     assert stream.observed_output.strip() == expected_output
 
 
+def test_block_opened():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.blockOpened('dummyMessage')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[blockOpened timestamp='2000-11-02T10:23:01.556' name='dummyMessage']
+        """).strip().encode('utf-8')
+
+
+def test_block_closed():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.blockClosed('dummyMessage')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[blockClosed timestamp='2000-11-02T10:23:01.556' name='dummyMessage']
+        """).strip().encode('utf-8')
+
+
+def test_compilation_started():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.compilationStarted('gcc')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[compilationStarted timestamp='2000-11-02T10:23:01.556' compiler='gcc']
+        """).strip().encode('utf-8')
+
+
+def test_compilation_finished():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.compilationFinished('gcc')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[compilationFinished timestamp='2000-11-02T10:23:01.556' compiler='gcc']
+        """).strip().encode('utf-8')
+
+
+def test_test_suite_started():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testSuiteStarted('suite emotion')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testSuiteStarted timestamp='2000-11-02T10:23:01.556' name='suite emotion']
+        """).strip().encode('utf-8')
+
+
+def test_test_suite_finished():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testSuiteFinished('suite emotion')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testSuiteFinished timestamp='2000-11-02T10:23:01.556' name='suite emotion']
+        """).strip().encode('utf-8')
+
+
+def test_test_started():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testStarted('only a test')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testStarted timestamp='2000-11-02T10:23:01.556' name='only a test']
+        """).strip().encode('utf-8')
+
+
+def test_test_finished():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testFinished('only a test')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testFinished timestamp='2000-11-02T10:23:01.556' name='only a test']
+        """).strip().encode('utf-8')
+
+
+def test_test_ignored():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testIgnored(testName='only a test', message='some message')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testIgnored timestamp='2000-11-02T10:23:01.556' message='some message' name='only a test']
+        """).strip().encode('utf-8')
+
+
+def test_test_failed():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testFailed(testName='only a test', message='some message', details='details')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testFailed timestamp='2000-11-02T10:23:01.556' details='details' message='some message' name='only a test']
+        """).strip().encode('utf-8')
+
+
+def test_test_stdout():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testStdOut(testName='only a test', out='out')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testStdOut timestamp='2000-11-02T10:23:01.556' name='only a test' out='out']
+        """).strip().encode('utf-8')
+
+
+def test_test_stderr():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testStdErr(testName='only a test', out='out')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testStdErr timestamp='2000-11-02T10:23:01.556' name='only a test' out='out']
+        """).strip().encode('utf-8')
+
+
+def test_progress_start():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.progressStart('doing stuff')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[progressStart 'doing stuff']
+        """).strip().encode('utf-8')
+
+
+def test_progress_finish():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.progressFinish('doing stuff')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[progressFinish 'doing stuff']
+        """).strip().encode('utf-8')
+
+
+def test_build_problem():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildProblem(description='something is wrong', identity='me')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[buildProblem timestamp='2000-11-02T10:23:01.556' description='something is wrong' identity='me']
+        """).strip().encode('utf-8')
+
+
+def test_build_status():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildStatus(status='failure', text='compile error')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[buildStatus timestamp='2000-11-02T10:23:01.556' status='failure' text='compile error']
+        """).strip().encode('utf-8')
+
+
+def test_set_parameter():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.setParameter(name='env', value='mt3')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[setParameter timestamp='2000-11-02T10:23:01.556' name='env' value='mt3']
+        """).strip().encode('utf-8')
+
+
+def test_build_statistic_lines_covered():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildStatisticLinesCovered(495)
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+            ##teamcity[buildStatisticValue timestamp='2000-11-02T10:23:01.556' key='CodeCoverageAbsLCovered' value='495']
+        """).strip().encode('utf-8')
+
+
+def test_build_statistic_total_lines():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildStatisticTotalLines(495)
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+            ##teamcity[buildStatisticValue timestamp='2000-11-02T10:23:01.556' key='CodeCoverageAbsLTotal' value='495']
+        """).strip().encode('utf-8')
+
+
+def test_build_statistic_lines_uncovered():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildStatisticLinesUncovered(5)
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+            ##teamcity[buildStatisticValue timestamp='2000-11-02T10:23:01.556' key='CodeCoverageAbsLUncovered' value='5']
+        """).strip().encode('utf-8')
+
+
+def test_enable_service_messages():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.enableServiceMessages()
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[enableServiceMessages timestamp='2000-11-02T10:23:01.556']
+        """).strip().encode('utf-8')
+
+
+def test_disable_service_messages():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.disableServiceMessages()
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[disableServiceMessages timestamp='2000-11-02T10:23:01.556']
+        """).strip().encode('utf-8')
+
+
+def test_import_data():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.importData('junit', '/path/to/junit.xml')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[importData timestamp='2000-11-02T10:23:01.556' path='/path/to/junit.xml' type='junit']
+        """).strip().encode('utf-8')
+
+
+def test_custom_message():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.customMessage('blah blah blah', status='all good')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[message timestamp='2000-11-02T10:23:01.556' errorDetails='' status='all good' text='blah blah blah']
+        """).strip().encode('utf-8')
+
+
 def test_no_properties():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)


### PR DESCRIPTION
Adds more methods; mostly context managers; and changes the way that context managers are implemented to a way that is much simpler but does not break Python 2.4 compatibility.

```python
#!/usr/bin/env python

from __future__ import with_statement

from teamcity.messages import TeamcityServiceMessages

m = TeamcityServiceMessages()

with m.block('Do stuff'):
    print('hello')

with m.compilation('gcc'):
    print('hello')

with m.test('foo'):
    print('hello')

with m.progress('Installing dependencies'):
    print('hello')

with m.serviceMessagesDisabled():
    print('hello')

with m.serviceMessagesEnabled():
    print('hello')
```

```
$ python2.5 test_context_managers.py

##teamcity[blockOpened timestamp='2015-09-13T10:47:03.166' name='Do stuff']
hello

##teamcity[blockClosed timestamp='2015-09-13T10:47:03.166' name='Do stuff']

##teamcity[compilationStarted timestamp='2015-09-13T10:47:03.166' compiler='gcc']
hello

##teamcity[compilationFinished timestamp='2015-09-13T10:47:03.166' compiler='gcc']

##teamcity[testStarted timestamp='2015-09-13T10:47:03.166' name='foo']
hello

##teamcity[testFinished timestamp='2015-09-13T10:47:03.166' name='foo']

##teamcity[progressStart 'Installing dependencies']
hello

##teamcity[progressFinish 'Installing dependencies']

##teamcity[disableServiceMessages timestamp='2015-09-13T10:47:03.166']
hello

##teamcity[enableServiceMessages timestamp='2015-09-13T10:47:03.166']

##teamcity[enableServiceMessages timestamp='2015-09-13T10:47:03.166']
hello

##teamcity[disableServiceMessages timestamp='2015-09-13T10:47:03.166']
```

```
$ python2.4 -c 'import teamcity.messages; print(teamcity.messages)'
<module 'teamcity.messages' from 'teamcity/messages.py'>
```

Also if [contextlib2](https://pypi.python.org/pypi/contextlib2) is installed, then these context managers can also function as decorators:

```python
from teamcity.messages import TeamcityServiceMessages

m = TeamcityServiceMessages()

@m.progress('long_thing')
def long_thing():
    print('foo')

long_thing()
```

```
$ python test_decorator.py

##teamcity[progressStart 'long_thing']
foo

##teamcity[progressFinish 'long_thing']
```

Cc: @shalupov, @sudarkoff, @aconrad, @djeebus