### PR TITLE
Add escape_value function

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -10,7 +10,7 @@ else:
     text_type = str
 
 
-_quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
+_quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", '[': '|[', ']': '|]'}
 
 def escape_value(value):
     return "".join([_quote.get(x, x) for x in value])

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -13,7 +13,7 @@ else:
 _quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", '[': '|[', ']': '|]'}
 
 def escape_value(value):
-    return "".join([_quote.get(x, x) for x in value])
+    return "".join(_quote.get(x, x) for x in value)
 
 
 class BlockContextManager(object):

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -10,6 +10,12 @@ else:
     text_type = str
 
 
+_quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
+
+def escape_value(value):
+    return "".join([_quote.get(x, x) for x in value])
+
+
 class BlockContextManager(object):
     """Context manager for logging blockOpened and blockClosed."""
     def __init__(self, name, messages, flowId):
@@ -40,8 +46,6 @@ class BlockContextManager(object):
 
 
 class TeamcityServiceMessages(object):
-    quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
-
     def __init__(self, output=sys.stdout, now=datetime.datetime.now, encoding='auto'):
         if sys.version_info < (3, ) or not hasattr(output, 'buffer'):
             self.output = output
@@ -60,7 +64,7 @@ class TeamcityServiceMessages(object):
             self.encoding = None
 
     def escapeValue(self, value):
-        return "".join([self.quote.get(x, x) for x in value])
+        return escape_value(value)
 
     def message(self, messageName, **properties):
         timestamp = self.now().strftime("%Y-%m-%dT%H:%M:%S.") + "%03d" % (self.now().microsecond / 1000)

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -264,9 +264,9 @@ def test_skip(venv):
 def test_params(venv):
     output = run(venv, 'params_test.py')
 
-    test1_name = 'tests.guinea-pigs.pytest.params_test.test_eval[3+5-8|]'
-    test2_name = "tests.guinea-pigs.pytest.params_test.test_eval[|'1_5|' + |'2|'-1_52|]"
-    test3_name = 'tests.guinea-pigs.pytest.params_test.test_eval[6*9-42|]'
+    test1_name = 'tests.guinea-pigs.pytest.params_test.test_eval|[3+5-8|]'
+    test2_name = "tests.guinea-pigs.pytest.params_test.test_eval|[|'1_5|' + |'2|'-1_52|]"
+    test3_name = 'tests.guinea-pigs.pytest.params_test.test_eval|[6*9-42|]'
 
     assert_service_messages(
         output,

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -1,4 +1,4 @@
-from teamcity.messages import TeamcityServiceMessages
+from teamcity.messages import TeamcityServiceMessages, escape_value
 from datetime import datetime
 import os
 import sys
@@ -28,6 +28,14 @@ class StreamStub(object):
         pass
 
 fixed_date = datetime(2000, 11, 2, 10, 23, 1, 556789)
+
+
+def test_escape_value():
+    assert escape_value("[square brackets]") == "|[square brackets|]"
+    assert escape_value("(parentheses)") == "(parentheses)"
+    assert escape_value("'single quotes'") == "|'single quotes|'"
+    assert escape_value("|vertical bars|") == "||vertical bars||"
+    assert escape_value("line1\nline2\nline3") == "line1|nline2|nline3"
 
 
 def test_no_properties():


### PR DESCRIPTION
In some cases, it might be useful to call `escape_value` as a simple function without instantiating a `TeamcityServiceMessages` object.

e.g.:

```python
In [1]: from teamcity.messages import escape_value

In [2]: escape_value("That's some text in [square brackets] and |vertical bars|\n")
Out[2]: "That|'s some text in [square brackets|] and ||vertical bars|||n"
```

This is useful to me, because I have some bash code that emits TeamCity messages and I would like to be able to reuse this Python code to do the escaping. With this, I can change the code from:

```bash
teamcity_escape() {
  echo "$@" | python -c 'import sys; from teamcity.messages import TeamcityServiceMessages; tc = TeamcityServiceMessages(); print(tc.escapeValue(sys.stdin.read()))'
}
```

to:

```bash
teamcity_escape() {
  echo "$@" | python -c 'import sys; from teamcity.messages import escape_value; print(tc.escape_value(sys.stdin.read()))'
}
```

Note that I provide a `escapeValue` function to be consistent with the camelCased names that this module uses, but I also provided `escape_value` as an alias because that is more Pythonic and compliant with [PEP-8](https://www.python.org/dev/peps/pep-0008/).

Cc: @sudarkoff, @aconrad, @0x9900