### PR TITLE
Add teamcity-escape cli program

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,10 @@ Issue Tracker: https://github.com/JetBrains/teamcity-messages/issues
     cmdclass={'test': PyTest},
 
     entry_points={
+        'console_scripts': [
+            'teamcity-escape = teamcity.messages:escape_value_prog',
+        ],
+
         'nose.plugins.0.10': [
             'teamcity-report = teamcity.nose_report:TeamcityReport'
         ],

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -10,6 +10,14 @@ else:
     text_type = str
 
 
+quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
+
+def escapeValue(value):
+    return "".join([quote.get(x, x) for x in value])
+
+escape_value = escapeValue
+
+
 class BlockContextManager(object):
     """Context manager for logging blockOpened and blockClosed."""
     def __init__(self, name, messages, flowId):
@@ -40,8 +48,6 @@ class BlockContextManager(object):
 
 
 class TeamcityServiceMessages(object):
-    quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", ']': '|]'}
-
     def __init__(self, output=sys.stdout, now=datetime.datetime.now, encoding='auto'):
         if sys.version_info < (3, ) or not hasattr(output, 'buffer'):
             self.output = output
@@ -60,7 +66,7 @@ class TeamcityServiceMessages(object):
             self.encoding = None
 
     def escapeValue(self, value):
-        return "".join([self.quote.get(x, x) for x in value])
+        return escapeValue(value)
 
     def message(self, messageName, **properties):
         timestamp = self.now().strftime("%Y-%m-%dT%H:%M:%S.") + "%03d" % (self.now().microsecond / 1000)

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -17,6 +17,10 @@ def escapeValue(value):
 
 escape_value = escapeValue
 
+def escape_value_prog():
+    for arg in sys.argv[1:]:
+        print(escape_value(arg))
+
 
 class BlockContextManager(object):
     """Context manager for logging blockOpened and blockClosed."""


### PR DESCRIPTION
Provides an easy way to do TeamCity escaping directly from the shell -- e.g.:

    $ teamcity-escape "That's some text in [square brackets] and |vertical bars|\n"
    That|'s some text in [square brackets|] and ||vertical bars||\n

Incorporates and builds upon change in #75.

Cc: @sudarkoff, @aconrad, @0x9900