### PR TITLE
tox.ini: py.test instead of python setup.py test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,7 @@
 envlist = py26, py27, pypy, py32, py33, py34, pypy3
 
 [testenv]
-commands = python setup.py test
+deps =
+    pytest
+    virtualenv
+commands = py.test {posargs:--showlocals --junitxml=test-result.xml tests/unit-tests tests/integration-tests tests/unit-tests-since-2.6}


### PR DESCRIPTION
and `py.test` is invoked with `{posargs}` so an advantage is that the user can pass arguments to `py.test` -- e.g.:

    tox -e py27 -- --pdb tests/unit-tests/messages_test.py