### PR TITLE
Allow passing args to setup.py test & tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
@@ -13,11 +19,12 @@ class PyTest(TestCommand):
         import pytest
         import sys
 
-        args = ["-l", "--junitxml=test-result.xml", "tests/unit-tests", "tests/integration-tests"]
-        if sys.version_info >= (2, 6):
-            args.append("tests/unit-tests-since-2.6")
+        if not self.pytest_args:
+            self.pytest_args = ["-l", "--junitxml=test-result.xml", "tests/unit-tests", "tests/integration-tests"]
+            if sys.version_info >= (2, 6):
+                self.pytest_args.append("tests/unit-tests-since-2.6")
 
-        errno = pytest.main(args)
+        errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py26, py27, pypy, py32, py33, py34, pypy3
 
 [testenv]
-commands = python setup.py test
+commands = python setup.py test {posargs}


### PR DESCRIPTION
e.g.:

    $ python setup.py test -a tests/unit-tests/messages_test.py
    ...
    tests/unit-tests/messages_test.py .....

    $ tox -e py27 -- -a tests/unit-tests/messages_test.py
    ...
    tests/unit-tests/messages_test.py .....
    ...