### PR TITLE
Do Unicode encoding in `_single_value_message`

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -87,7 +87,14 @@ class TeamcityServiceMessages(object):
         self.output.flush()
 
     def _single_value_message(self, messageName, value):
-        self.output.write("\n##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
+        message = ("\n##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
+
+        if self.encoding and isinstance(message, text_type):
+            message = message.encode(self.encoding)
+
+        # Python may buffer it for a long time, flushing helps to see real-time result
+        self.output.write(message)
+        self.output.flush()
 
     def testSuiteStarted(self, suiteName, flowId=None):
         self.message('testSuiteStarted', name=suiteName, flowId=flowId)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -59,11 +59,15 @@ def test_progress_message():
 def test_progress_message_unicode():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
-    unicode_str = b'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir'.decode('utf-8')
-    messages.progressMessage(unicode_str)
-    assert stream.observed_output.strip() == textwrap.dedent(b"""\
-        ##teamcity[progressMessage 'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir']
-        """.decode('utf-8')).encode('utf-8').strip()
+    if sys.version_info < (3, ):
+        bjork = 'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir'.decode('utf-8')
+    else:
+        bjork = b('Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir').decode('utf-8')
+    messages.progressMessage(bjork)
+    expected_output = b(
+        "##teamcity[progressMessage "
+        "'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir']")
+    assert stream.observed_output.strip() == expected_output
 
 
 def test_no_properties():

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -38,6 +38,24 @@ def test_escape_value():
     assert escape_value("line1\nline2\nline3") == "line1|nline2|nline3"
 
 
+def test_publish_artifacts():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.publishArtifacts('/path/to/file')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[publishArtifacts '/path/to/file']
+        """).strip().encode('utf-8')
+
+
+def test_progress_message():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.progressMessage('doing stuff')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[progressMessage 'doing stuff']
+        """).strip().encode('utf-8')
+
+
 def test_no_properties():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -56,6 +56,16 @@ def test_progress_message():
         """).strip().encode('utf-8')
 
 
+def test_progress_message_unicode():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    unicode_str = b'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir'.decode('utf-8')
+    messages.progressMessage(unicode_str)
+    assert stream.observed_output.strip() == textwrap.dedent(b"""\
+        ##teamcity[progressMessage 'Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir']
+        """.decode('utf-8')).encode('utf-8').strip()
+
+
 def test_no_properties():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)


### PR DESCRIPTION
Fixes failing tests in Python 3.4:

    $ tox -e py34 -- -a tests/unit-tests
    ...
    tests/unit-tests/messages_test.py::test_publish_artifacts FAILED
    tests/unit-tests/messages_test.py::test_progress_message FAILED
    tests/unit-tests/messages_test.py::test_progress_start FAILED
    tests/unit-tests/messages_test.py::test_progress_finish FAILED
    ...

Cc: @sudarkoff, @djeebus 