### PR TITLE
setup.py: Use setuptools_scm

### DIFF
--- a/.travis-make-py24-virtualenv.sh
+++ b/.travis-make-py24-virtualenv.sh
@@ -15,11 +15,11 @@ EOF
 ./configure --prefix=$PWD/install
 make
 make install
-# This is the last version of virtualenv to support python 2.4:
-wget -O virtualenv.py https://raw.github.com/pypa/virtualenv/1.7.2/virtualenv.py
+# Install an old version of virtualenv that supports python 2.4:
+wget -O virtualenv.py https://raw.github.com/pypa/virtualenv/1.3.4/virtualenv.py
 # And this is the last version of pip to support python 2.4. If
 # there's a file matching "^pip-.*(zip|tar.gz|tar.bz2|tgz|tbz)$" in
 # the current directory then virtualenv will take that as the pip
 # source distribution to install
 wget -O pip-1.1.tar.gz http://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz
-install/bin/python2.4 ./virtualenv.py --distribute $VIRTENV
+install/bin/python2.4 ./virtualenv.py $VIRTENV

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ class PyTest(TestCommand):
 
 setup(
     name="teamcity-messages",
-    version="1.16",
+    setup_requires=['setuptools_scm'],
+    use_scm_version=True,
     author='JetBrains',
     author_email='teamcity-feedback@jetbrains.com',
     description='Send test results ' +


### PR DESCRIPTION
Use [setuptools_scm](https://pypi.python.org/pypi/setuptools_scm) instead of hard-coded version number, which is a burden to update.

This hopefully will help with issues like https://github.com/JetBrains/teamcity-messages/issues/82