### PR TITLE
Enable automatically when TeamCity running

### DIFF
--- a/teamcity/flake8_plugin.py
+++ b/teamcity/flake8_plugin.py
@@ -2,11 +2,12 @@ import pep8
 import re
 
 from teamcity.messages import TeamcityServiceMessages
+from teamcity import is_running_under_teamcity
 
 
 name = 'teamcity'
 version = '1.9'
-enable_teamcity = False
+enable_teamcity = is_running_under_teamcity()
 
 
 def add_options(parser):

--- a/tests/integration-tests/flake8_test.py
+++ b/tests/integration-tests/flake8_test.py
@@ -50,7 +50,6 @@ def test_no_reporting_without_explicit_option(venv):
 
 def run(venv, options):
     env = virtual_environments.get_clean_system_environment()
-    env['TEAMCITY_VERSION'] = "0.0.0"
 
     command = os.path.join(
         os.getcwd(), venv.bin,


### PR DESCRIPTION
so that user doesn't have to pass `--teamcity` option just when using TeamCity. If you have a `tox.ini`, you don't want to modify the `tox.ini` to pass `--teamcity` just when in TeamCity.

The `pytest` plugin seems to already work like this, so it seems to make sense to make the `flake8` plugin do the same.