### PR TITLE
Fix twisted failure test reporting

### DIFF
--- a/twisted/plugins/teamcity_plugin.py
+++ b/twisted/plugins/teamcity_plugin.py
@@ -1,7 +1,14 @@
 import sys
 from teamcity.unittestpy import TeamcityTestResult
 from twisted.trial.reporter import Reporter
+from twisted.python.failure import Failure
 from twisted.plugins.twisted_trial import _Reporter
+
+
+class FailureWrapper(Failure):
+
+    def __getitem__(self, key):
+        return self.value[key]
 
 
 class TeamcityReporter(TeamcityTestResult, Reporter):
@@ -17,6 +24,9 @@ class TeamcityReporter(TeamcityTestResult, Reporter):
                           tbformat=tbformat,
                           realtime=realtime,
                           publisher=publisher)
+
+    def addError(self, test, failure, *k):
+        super(TeamcityReporter, self).addError(test, FailureWrapper(failure), *k)
 
 Teamcity = _Reporter("Teamcity Reporter",
                      "twisted.plugins.teamcity_plugin",


### PR DESCRIPTION
In case of some twisted trial test failed, teamcity reporter throw exception.

2015-10-22 14:39:51+0500 -
2015-10-22 14:39:51+0500 [-] Stopping factory 
2015-10-22 14:39:51+0500 [HTTP11ClientProtocol,client] Stopping factory 
2015-10-22 14:39:51+0500 [-] Main loop terminated.
2015-10-22 14:39:51+0500 [-] Traceback (most recent call last):
2015-10-22 14:39:51+0500 [-] File "/usr/local/bin/trial", line 18, in 
2015-10-22 14:39:51+0500 [-] run()
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/scripts/trial.py", line 616, in run
2015-10-22 14:39:51+0500 [-] test_result = trialRunner.run(suite)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 730, in run
2015-10-22 14:39:51+0500 [-] return self.runWithoutDecoration(test, self.forceGarbageCollection)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 757, in _runWithoutDecoration
2015-10-22 14:39:51+0500 [-] run()
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 752, in 
2015-10-22 14:39:51+0500 [-] run = lambda: suite.run(result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 221, in run
2015-10-22 14:39:51+0500 [-] TestSuite.run(self, result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/_asyncrunner.py", line 38, in run
2015-10-22 14:39:51+0500 [-] test(result)
2015-10-22 14:39:51+0500 [-] File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/suite.py", line 70, in __call
2015-10-22 14:39:51+0500 [-] return self.run(args, *kwds)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 180, in run
2015-10-22 14:39:51+0500 [-] super(LoggedSuite, self).run(result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/asyncrunner.py", line 38, in run
2015-10-22 14:39:51+0500 [-] test(result)
2015-10-22 14:39:51+0500 [-] File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/suite.py", line 70, in __call_
2015-10-22 14:39:51+0500 [-] return self.run(args, *kwds)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/runner.py", line 153, in run
2015-10-22 14:39:51+0500 [-] test(result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/asynctest.py", line 119, in __call_
2015-10-22 14:39:51+0500 [-] return self.run(args, *kwargs)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/synctest.py", line 1024, in run
2015-10-22 14:39:51+0500 [-] collectWarnings(self._warnings.append, self._runFixturesAndTest, result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/_synctest.py", line 182, in _collectWarnings
2015-10-22 14:39:51+0500 [-] result = f(args, *kwargs)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/_asynctest.py", line 302, in _runFixturesAndTest
2015-10-22 14:39:51+0500 [-] self._cleanUp(result)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/twisted/trial/_asynctest.py", line 216, in _cleanUp
2015-10-22 14:39:51+0500 [-] result.addError(self, error)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/teamcity_messages-1.14-py2.7.egg/twisted/plugins/teamcity_plugin.py", line 22, in addError
2015-10-22 14:39:51+0500 [-] super(TeamcityReporter, self).addError(test, failure, *k)
2015-10-22 14:39:51+0500 [-] File "/Library/Python/2.7/site-packages/teamcity_messages-1.14-py2.7.egg/teamcity/unittestpy.py", line 80, in addError
2015-10-22 14:39:51+0500 [-] elif get_class_fullname(err[0]) == "unittest2.case.SkipTest":
2015-10-22 14:39:51+0500 [-] AttributeError: Failure instance has no attribute '__getitem'