### PR TITLE
flake8: Show error text

### DIFF
--- a/teamcity/flake8_plugin.py
+++ b/teamcity/flake8_plugin.py
@@ -47,8 +47,8 @@ class TeamcityReport(pep8.StandardReport):
                 'col': offset + 1,
             }
 
-            error_message = '%s: %s' % (code, text)
-            test_name = '%s: %s' % (code, position)
+            error_message = '%s %s' % (code, text)
+            test_name = '%s: %s' % (position, error_message)
 
             messages.testStarted(test_name)
 


### PR DESCRIPTION
in adddition to error code, because the text is more human-readable than the code.

Changes `testStarted` message from - e.g.:

    ##teamcity[testStarted timestamp='2015-10-22T09:40:02.415' name='E501: smstack/ansible/plugins/teamcity_messages.py:204:80']

to:

    ##teamcity[testStarted timestamp='2015-10-22T09:44:46.852' name='smstack/ansible/plugins/teamcity_messages.py:204:80: E501 line too long (82 > 79 characters)']

and the TeamCity UI presentation changes from:

<img width="812" alt="screen shot 2015-10-22 at 10 07 24 am" src="https://cloud.githubusercontent.com/assets/305268/10672427/fa194b38-78a4-11e5-8ea4-bb412c64836e.png">

to:

<img width="724" alt="screen shot 2015-10-22 at 10 08 10 am" src="https://cloud.githubusercontent.com/assets/305268/10672425/f45acaf0-78a4-11e5-9434-c1808711efc3.png">
