### PR TITLE
Don't force a newline at the start of service messages.

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -39,7 +39,7 @@ class TeamcityServiceMessages(object):
 
     def message(self, messageName, **properties):
         timestamp = self.now().strftime("%Y-%m-%dT%H:%M:%S.") + "%03d" % (self.now().microsecond / 1000)
-        message = ("\n##teamcity[%s timestamp='%s'" % (messageName, timestamp))
+        message = ("##teamcity[%s timestamp='%s'" % (messageName, timestamp))
 
         for k in sorted(properties.keys()):
             value = properties[k]
@@ -58,7 +58,7 @@ class TeamcityServiceMessages(object):
         self.output.flush()
 
     def _single_value_message(self, messageName, value):
-        message = ("\n##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
+        message = ("##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
 
         if self.encoding and isinstance(message, text_type):
             message = message.encode(self.encoding)

--- a/tests/integration-tests/service_messages.py
+++ b/tests/integration-tests/service_messages.py
@@ -50,8 +50,9 @@ def parse_service_messages(text):
     messages = list()
     for line in text.splitlines():
         r = line.strip()
-        if r.startswith("##teamcity[") and r.endswith("]"):
-            m = _parse_one_service_message(r)
+        index = r.find("##teamcity[")
+        if index != -1:
+            m = _parse_one_service_message(r[index:])
             messages.append(m)
     return messages
 
@@ -109,7 +110,7 @@ def assert_service_messages(actual_messages_string, expected_messages):
 
     try:
         if len(actual_messages) != len(expected_messages):
-            raise AssertionError("Expected %d services messages, but got %d" % (len(expected_messages), len(actual_messages)))
+            raise AssertionError("Expected %d service messages, but got %d" % (len(expected_messages), len(actual_messages)))
         for index, (actual, expected) in enumerate(zip(actual_messages, expected_messages)):
             assert actual >= expected, "Expected\n%s, but got\n%s\n at index %d" % (pprint.pformat(expected), pprint.pformat(actual), index)
     except:

--- a/tests/unit-tests-since-2.6/messages26_test.py
+++ b/tests/unit-tests-since-2.6/messages26_test.py
@@ -21,11 +21,9 @@ def test_blocks():
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     with messages.block("Doing something that's important"):
         messages.message("Doing stuff")
-    expected_output = textwrap.dedent("""
+    expected_output = textwrap.dedent("""\
         ##teamcity[blockOpened timestamp='2000-11-02T10:23:01.556' name='Doing something that|'s important']
-
         ##teamcity[Doing stuff timestamp='2000-11-02T10:23:01.556']
-
         ##teamcity[blockClosed timestamp='2000-11-02T10:23:01.556' name='Doing something that|'s important']
         """)
     expected_output = expected_output.encode('utf-8')
@@ -37,11 +35,9 @@ def test_blocks_with_flowid():
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     with messages.block("Doing something that's important", flowId='a'):
         messages.message("Doing stuff")
-    expected_output = textwrap.dedent("""
+    expected_output = textwrap.dedent("""\
         ##teamcity[blockOpened timestamp='2000-11-02T10:23:01.556' flowId='a' name='Doing something that|'s important']
-
         ##teamcity[Doing stuff timestamp='2000-11-02T10:23:01.556']
-
         ##teamcity[blockClosed timestamp='2000-11-02T10:23:01.556' flowId='a' name='Doing something that|'s important']
         """)
     expected_output = expected_output.encode('utf-8')
@@ -55,7 +51,6 @@ def test_compilation():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[compilationStarted timestamp='2000-11-02T10:23:01.556' compiler='gcc']
-
         ##teamcity[compilationFinished timestamp='2000-11-02T10:23:01.556' compiler='gcc']
         """).strip().encode('utf-8')
 
@@ -67,7 +62,6 @@ def test_test_suite():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[testSuiteStarted timestamp='2000-11-02T10:23:01.556' name='suite emotion']
-
         ##teamcity[testSuiteFinished timestamp='2000-11-02T10:23:01.556' name='suite emotion']
         """).strip().encode('utf-8')
 
@@ -79,7 +73,6 @@ def test_test():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[testStarted timestamp='2000-11-02T10:23:01.556' name='only a test']
-
         ##teamcity[testFinished timestamp='2000-11-02T10:23:01.556' name='only a test']
         """).strip().encode('utf-8')
 
@@ -91,7 +84,6 @@ def test_progress():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[progressStart 'only a test']
-
         ##teamcity[progressFinish 'only a test']
         """).strip().encode('utf-8')
 
@@ -103,7 +95,6 @@ def test_service_messages_disabled():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[disableServiceMessages timestamp='2000-11-02T10:23:01.556']
-
         ##teamcity[enableServiceMessages timestamp='2000-11-02T10:23:01.556']
         """).strip().encode('utf-8')
 
@@ -115,6 +106,5 @@ def test_service_messages_enabled():
         pass
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[enableServiceMessages timestamp='2000-11-02T10:23:01.556']
-
         ##teamcity[disableServiceMessages timestamp='2000-11-02T10:23:01.556']
         """).strip().encode('utf-8')

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -290,21 +290,21 @@ def test_no_properties():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     messages.message('dummyMessage')
-    assert stream.observed_output == "\n##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556']\n".encode('utf-8')
+    assert stream.observed_output == "##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556']\n".encode('utf-8')
 
 
 def test_one_property():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     messages.message('dummyMessage', fruit='apple')
-    assert stream.observed_output == "\n##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple']\n".encode('utf-8')
+    assert stream.observed_output == "##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple']\n".encode('utf-8')
 
 
 def test_three_properties():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
     messages.message('dummyMessage', fruit='apple', meat='steak', pie='raspberry')
-    assert stream.observed_output == "\n##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple' meat='steak' pie='raspberry']\n".encode('utf-8')
+    assert stream.observed_output == "##teamcity[dummyMessage timestamp='2000-11-02T10:23:01.556' fruit='apple' meat='steak' pie='raspberry']\n".encode('utf-8')
 
 
 def test_unicode():
@@ -315,7 +315,7 @@ def test_unicode():
     else:
         bjork = b('Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir').decode('utf-8')
     messages.message(bjork)
-    assert stream.observed_output == ("\n##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork).encode('utf-8')
+    assert stream.observed_output == ("##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % bjork).encode('utf-8')
 
 
 def test_unicode_to_sys_stdout_with_no_encoding():


### PR DESCRIPTION
This practice creates unnecessary blank lines in the TeamCity build log,
which is distracting when reading the output. Experimentally, TeamCity
does not seem to need *any* whitespace before a service message
start, so we remove it.

Changes:
* Remove forced leading newline when writing a service message.
* Update expected test output to not look for new lines.
* Update the test output parser (parse_service_messages) to not expect
  service messages to start on a newline.