### PR TITLE
Skip status reporting on flaky test retry (fix #94)

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -136,6 +136,11 @@ class EchoTeamCityMessages(object):
         duration = timedelta(seconds=report.duration)
 
         if report.passed:
+            # Do not report if we have a "failed" original_outcome. This key is
+            # created by box/Flaky pytest plugin when it'll retry running a
+            if getattr(report, 'original_outcome', None) == 'failed':
+                return
+
             # Do not report passed setup/teardown if no output
             if report.when == 'call' or self.report_has_output(report):
                 self.ensure_test_start_reported(test_id)


### PR DESCRIPTION
Sending this PR to contribute to the discussion around #94. This code feel pretty hacky to me, but I don't know any better way of detecting flaky will handle a test retry.

Maybe @Jeff-Meadows have an opinion/direction about this. (I hope you don't mind me tagging you here)