### PR TITLE
Make sure to turn reason into string when skipping test

### DIFF
--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -52,7 +52,7 @@ class TeamcityTestResult(TestResult):
         test_id = self.get_test_id(test)
 
         if reason:
-            reason_str = ": " + reason
+            reason_str = ": " + reason.__str__()
         else:
             reason_str = ""
         self.messages.testIgnored(test_id, message="Skipped" + reason_str, flowId=test_id)


### PR DESCRIPTION
A custom Test loader map pass the an Exception object for reason.
nosetests custom TestLoader does this.

You can see an example project where we see the bug: https://github.com/piyushg91/broken-teamcity-messages where it 