### PR TITLE
Make sure to turn reason into string when skipping test

### DIFF
--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -52,7 +52,7 @@ class TeamcityTestResult(TestResult):
         test_id = self.get_test_id(test)
 
         if reason:
-            reason_str = ": " + reason
+            reason_str = ": " + reason.__str__()
         else:
             reason_str = ""
         self.messages.testIgnored(test_id, message="Skipped" + reason_str, flowId=test_id)


### PR DESCRIPTION
A custom Test loader may pass an Exception object into the reason
variable when skipping a test.

nosetests custom test loader does this so we should make sure reason is
a string before concatenating

Please see https://github.com/piyushg91/broken-teamcity-messages as an example of a case where this bug exists. 