### PR TITLE
More deterministic flake8 test names to ease muting them

### DIFF
--- a/teamcity/flake8_v2_plugin.py
+++ b/teamcity/flake8_v2_plugin.py
@@ -54,7 +54,7 @@ class TeamcityReport(pep8.StandardReport):
             }
 
             error_message = '%s %s' % (code, text)
-            test_name = 'pep8: %s: %s' % (position, error_message)
+            test_name = 'pep8: %s: %s' % (normalized_filename, error_message)
 
             messages.testStarted(test_name)
 
@@ -64,6 +64,7 @@ class TeamcityReport(pep8.StandardReport):
                 line = self.lines[line_number - 1]
 
             details = [
+                position,
                 line.rstrip(),
                 re.sub(r'\S', ' ', line[:offset]) + '^',
             ]

--- a/teamcity/flake8_v3_plugin.py
+++ b/teamcity/flake8_v3_plugin.py
@@ -35,11 +35,12 @@ class TeamcityReport(base.BaseFormatter):
         position = '%s:%d:%d' % (
             normalized_filename, error.line_number, error.column_number)
         error_message = '%s %s' % (error.code, error.text)
-        test_name = 'pep8: %s: %s' % (position, error_message)
+        test_name = 'pep8: %s: %s' % (normalized_filename, error_message)
 
         line = error.physical_line
         offset = error.column_number
         details = [
+            position,
             line.rstrip(),
             re.sub(r'\S', ' ', line[:offset]) + '^',
         ]

--- a/tests/integration-tests/flake8_test.py
+++ b/tests/integration-tests/flake8_test.py
@@ -22,8 +22,8 @@ def test_smoke_flake8_v2(venv_flake8_v2):
     output = run(venv_flake8_v2, options="--teamcity", set_tc_version=False)
 
     file_name = "./smoke.py"
-    test1_name = "pep8: " + file_name + ":3:1: E302 expected 2 blank lines, found 1"
-    test2_name = "pep8: " + file_name + ":7:1: W391 blank line at end of file"
+    test1_name = "pep8: " + file_name + ": E302 expected 2 blank lines, found 1"
+    test2_name = "pep8: " + file_name + ": W391 blank line at end of file"
 
     assert_service_messages(
         output,
@@ -43,8 +43,8 @@ def test_smoke_flake8_v3(venv_flake8_v3):
     output = run(venv_flake8_v3, options="")
 
     file_name = "./smoke.py"
-    test1_name = "pep8: " + file_name + ":3:1: E302 expected 2 blank lines, found 1"
-    test2_name = "pep8: " + file_name + ":7:1: W391 blank line at end of file"
+    test1_name = "pep8: " + file_name + ": E302 expected 2 blank lines, found 1"
+    test2_name = "pep8: " + file_name + ": W391 blank line at end of file"
 
     assert_service_messages(
         output,


### PR DESCRIPTION
pep8: example.py:3:1: E302 expected 2 blank lines, found 1
->
pep8: example.py: E302 expected 2 blank lines, found 1

Flake8 tests names included line number and position, so
it's almost impossible to keep test muted after minor file refactoring,
because basically line number changes and new test name is
not muted.

Previous behavior breaks a workflow when one wants to
keep mccabe complexity low, but keep legacy code failed tests muted.