### PR TITLE
https://github.com/JetBrains/teamcity-messages/issues/123

### DIFF
--- a/teamcity/common.py
+++ b/teamcity/common.py
@@ -115,10 +115,10 @@ def get_class_fullname(something):
     return module + '.' + cls.__name__
 
 
-def convert_error_to_string(err):
+def convert_error_to_string(err, frames_to_skip_from_tail=0):
     try:
         exctype, value, tb = err
-        return ''.join(traceback.format_exception(exctype, value, tb))
+        return ''.join(traceback.format_exception(exctype, value, tb)[:-frames_to_skip_from_tail])
     except:
         tb = traceback.format_exc()
         return "*FAILED TO GET TRACEBACK*: " + tb

--- a/teamcity/diff_tools.py
+++ b/teamcity/diff_tools.py
@@ -1,0 +1,59 @@
+import base64
+import pprint
+import sys
+import unittest
+
+_PY2K = sys.version_info < (3,)
+
+
+def patch_unittest_diff():
+    """
+    Patches "assertEquals" to throw DiffError
+    """
+    def _patched_equals(_, first, second, msg=None):
+        if first != second:
+            raise DiffError(first, second, msg)
+
+    unittest.TestCase.assertEqual = _patched_equals
+
+
+def _format_and_convert(string):
+    string = pprint.pformat(string)
+    return string if _PY2K else bytes(str(string), "utf-8")
+
+
+class DiffError(AssertionError):
+
+    def __init__(self, expected, actual, msg=None, preformated=False):
+        super(AssertionError, self).__init__()
+        self.expected = expected
+        self.actual = actual
+        self.msg = msg
+
+        if preformated:
+            return
+        self.expected = pprint.pformat(self.expected)
+        self.actual = pprint.pformat(self.actual)
+        self.msg = msg if msg else ""
+
+    def __str__(self):
+        return self._serialize()
+
+    def __unicode__(self):
+        return self._serialize()
+
+    def _serialize(self):
+        def fix_type(msg):
+            return msg if _PY2K else bytes(str(msg), "utf-8")
+
+        encoded_fields = [base64.b64encode(fix_type(x)) for x in [self.expected, self.actual, self.msg]]
+        if not _PY2K:
+            encoded_fields = [bytes.decode(x) for x in encoded_fields]
+        return "|".join(encoded_fields)
+
+
+def deserialize_error(serialized_message):
+    parts = [base64.b64decode(x) for x in str(serialized_message).split("|")]
+    if not _PY2K:
+        parts = [bytes.decode(x) for x in parts]
+    return DiffError(parts[0], parts[1], parts[2], preformated=True)

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 import sys
 import time
+from .diff_tools import patch_unittest_diff, DiffError
+
+patch_unittest_diff()
+
 
 if sys.version_info < (3, ):
     # Python 2
@@ -8,7 +12,6 @@ if sys.version_info < (3, ):
 else:
     # Python 3
     text_type = str
-
 
 # Capture some time functions to allow monkeypatching them in tests
 _time = time.time
@@ -141,8 +144,18 @@ class TeamcityServiceMessages(object):
     def testIgnored(self, testName, message='', flowId=None):
         self.message('testIgnored', name=testName, message=message, flowId=flowId)
 
-    def testFailed(self, testName, message='', details='', flowId=None):
-        self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+    def testFailed(self, testName, message='', details='', flowId=None, diff_failed=None):
+        if not diff_failed:
+            self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+        else:
+            self.message('testFailed',
+                         name=testName,
+                         message=message,
+                         details=details,
+                         flowId=flowId,
+                         type="comparisonFailure",
+                         actual=diff_failed.actual,
+                         expected=diff_failed.expected)
 
     def testStdOut(self, testName, out, flowId=None):
         self.message('testStdOut', name=testName, out=out, flowId=flowId)

--- a/teamcity/nose_report.py
+++ b/teamcity/nose_report.py
@@ -6,7 +6,7 @@ import inspect
 
 from teamcity import is_running_under_teamcity
 from teamcity.common import is_string, get_class_fullname, convert_error_to_string, dump_test_stdout, FlushingStringIO
-from teamcity.messages import TeamcityServiceMessages
+from teamcity.messages import TeamcityServiceMessages, DiffError
 
 import nose
 # noinspection PyPackageRequirements
@@ -144,6 +144,14 @@ class TeamcityReport(Plugin):
             # do not log test output twice, see report_finish for actual output handling
             details = details[:start_index] + details[end_index + len(_captured_output_end_marker):]
 
+        try:
+            error = err[1]
+            if isinstance(error, DiffError):
+                details = convert_error_to_string(err, 2)
+                self.messages.testFailed(test_id, message=error.msg, details=details, flowId=test_id, diff_failed=error)
+                return
+        except:
+            pass
         self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
 
     def report_finish(self, test):

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -4,7 +4,7 @@ from unittest import TestResult, TextTestRunner
 import datetime
 import re
 
-from teamcity.messages import TeamcityServiceMessages
+from teamcity.messages import TeamcityServiceMessages, DiffError
 from teamcity.common import is_string, get_class_fullname, convert_error_to_string, \
     dump_test_stdout, dump_test_stderr, get_exception_message, to_unicode, FlushingStringIO
 
@@ -189,19 +189,37 @@ class TeamcityTestResult(TestResult):
     def report_fail(self, test, fail_type, err):
         test_id = self.get_test_id(test)
 
+        diff_failed = None
+        try:
+            error = err[1]
+            if isinstance(error, DiffError):
+                diff_failed = error
+        except:
+            pass
+
+
         if is_string(err):
             details = err
         elif get_class_fullname(err) == "twisted.python.failure.Failure":
             details = err.getTraceback()
         else:
-            details = convert_error_to_string(err)
+            frames_to_skip_from_tail = 2 if diff_failed else 0
+            details = convert_error_to_string(err, frames_to_skip_from_tail)
 
         subtest_failures = self.get_subtest_failure(test_id)
         if subtest_failures:
             details = "Failed subtests list: " + subtest_failures + "\n\n" + details.strip()
             details = details.strip()
 
-        self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
+
+        if diff_failed:
+          self.messages.testFailed(test_id,
+                                   message=diff_failed.msg,
+                                   details=details,
+                                   flowId=test_id,
+                                   diff_failed=diff_failed)
+        else:
+             self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
         self.failed_tests.add(test_id)
 
     def startTest(self, test):


### PR DESCRIPTION
Support "comparisonFailure" protocol for TC.

This code monkeypatches testEquals forcing it to throw DiffError.

This class either fetched directly from failure or serialized/deserialized
(see diff_tools) to obtain "expected" and "actual" fields.

They are provided to TC (and InteliJ) to display fancy diff viewer.