### PR TITLE
https://github.com/JetBrains/teamcity-messages/issues/123

### DIFF
--- a/teamcity/common.py
+++ b/teamcity/common.py
@@ -115,10 +115,10 @@ def get_class_fullname(something):
     return module + '.' + cls.__name__
 
 
-def convert_error_to_string(err):
+def convert_error_to_string(err, frames_to_skip_from_tail=0):
     try:
         exctype, value, tb = err
-        return ''.join(traceback.format_exception(exctype, value, tb))
+        return ''.join(traceback.format_exception(exctype, value, tb)[:-frames_to_skip_from_tail])
     except:
         tb = traceback.format_exc()
         return "*FAILED TO GET TRACEBACK*: " + tb

--- a/teamcity/diff_tools.py
+++ b/teamcity/diff_tools.py
@@ -1,0 +1,67 @@
+import base64
+import pprint
+import sys
+import unittest
+
+_PY2K = sys.version_info < (3,)
+_PRIMITIVES = [int, str, bool]
+if _PY2K:
+    # Not available in py3
+    # noinspection PyUnresolvedReferences
+    _PRIMITIVES.append(unicode)
+
+
+
+def patch_unittest_diff():
+    """
+    Patches "assertEquals" to throw DiffError
+    """
+    if sys.version_info < (2, 7):
+        return
+    def _patched_equals(_, first, second, msg=None):
+        if first != second:
+            raise EqualsAssertionError(first, second, msg)
+
+    unittest.TestCase.assertEqual = _patched_equals
+
+
+def _format_and_convert(val):
+    # No need to pretty-print primitives
+    return val if any(x for x in _PRIMITIVES if isinstance(val, x)) else pprint.pformat(val)
+
+
+class EqualsAssertionError(AssertionError):
+
+    def __init__(self, expected, actual, msg=None, preformated=False):
+        super(AssertionError, self).__init__()
+        self.expected = expected
+        self.actual = actual
+        self.msg = msg
+
+        if preformated:
+            return
+        self.expected = _format_and_convert(self.expected)
+        self.actual = _format_and_convert(self.actual)
+        self.msg = msg if msg else ""
+
+    def __str__(self):
+        return self._serialize()
+
+    def __unicode__(self):
+        return self._serialize()
+
+    def _serialize(self):
+        def fix_type(msg):
+            return msg if _PY2K else bytes(str(msg), "utf-8")
+
+        encoded_fields = [base64.b64encode(fix_type(x)) for x in [self.expected, self.actual, self.msg]]
+        if not _PY2K:
+            encoded_fields = [bytes.decode(x) for x in encoded_fields]
+        return "|".join(encoded_fields)
+
+
+def deserialize_error(serialized_message):
+    parts = [base64.b64decode(x) for x in str(serialized_message).split("|")]
+    if not _PY2K:
+        parts = [bytes.decode(x) for x in parts]
+    return EqualsAssertionError(parts[0], parts[1], parts[2], preformated=True)

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 import sys
 import time
+from .diff_tools import patch_unittest_diff, EqualsAssertionError
+
+patch_unittest_diff()
+
 
 if sys.version_info < (3, ):
     # Python 2
@@ -8,7 +12,6 @@ if sys.version_info < (3, ):
 else:
     # Python 3
     text_type = str
-
 
 # Capture some time functions to allow monkeypatching them in tests
 _time = time.time
@@ -141,8 +144,18 @@ class TeamcityServiceMessages(object):
     def testIgnored(self, testName, message='', flowId=None):
         self.message('testIgnored', name=testName, message=message, flowId=flowId)
 
-    def testFailed(self, testName, message='', details='', flowId=None):
-        self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+    def testFailed(self, testName, message='', details='', flowId=None, diff_failed=None):
+        if not diff_failed:
+            self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+        else:
+            self.message('testFailed',
+                         name=testName,
+                         message=message,
+                         details=details,
+                         flowId=flowId,
+                         type="comparisonFailure",
+                         actual=diff_failed.actual,
+                         expected=diff_failed.expected)
 
     def testStdOut(self, testName, out, flowId=None):
         self.message('testStdOut', name=testName, out=out, flowId=flowId)

--- a/teamcity/nose_report.py
+++ b/teamcity/nose_report.py
@@ -6,7 +6,7 @@ import inspect
 
 from teamcity import is_running_under_teamcity
 from teamcity.common import is_string, get_class_fullname, convert_error_to_string, dump_test_stdout, FlushingStringIO
-from teamcity.messages import TeamcityServiceMessages
+from teamcity.messages import TeamcityServiceMessages, EqualsAssertionError
 
 import nose
 # noinspection PyPackageRequirements
@@ -144,6 +144,14 @@ class TeamcityReport(Plugin):
             # do not log test output twice, see report_finish for actual output handling
             details = details[:start_index] + details[end_index + len(_captured_output_end_marker):]
 
+        try:
+            error = err[1]
+            if isinstance(error, EqualsAssertionError):
+                details = convert_error_to_string(err, 2)
+                self.messages.testFailed(test_id, message=error.msg, details=details, flowId=test_id, diff_failed=error)
+                return
+        except:
+            pass
         self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
 
     def report_finish(self, test):

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -17,9 +17,30 @@ import re
 import traceback
 from datetime import timedelta
 
+from .diff_tools import EqualsAssertionError
 from teamcity.messages import TeamcityServiceMessages
 from teamcity.common import convert_error_to_string, dump_test_stderr, dump_test_stdout
 from teamcity import is_running_under_teamcity
+from teamcity import diff_tools
+
+
+def fetch_diff_error_from_message(err_message):
+    line_with_diff = None
+    diff_error_message = None
+    lines = err_message.split("\n")
+    if err_message.startswith("AssertionError: assert"):
+        # Everything in one line
+        line_with_diff = lines[0][len("AssertionError: assert "):]
+    elif len(err_message.split("\n")) > 1:
+        err_line = lines[1]
+        line_with_diff = err_line[len("assert "):]
+        diff_error_message = lines[0]
+
+    if line_with_diff and line_with_diff.count("==") == 1:
+        parts = [x.strip() for x in line_with_diff.split("==")]
+        return EqualsAssertionError(parts[0][1:-1], parts[1][1:-1], diff_error_message)
+    else:
+        return None
 
 
 def pytest_addoption(parser):
@@ -191,7 +212,34 @@ class EchoTeamCityMessages(object):
         self.ensure_test_start_reported(test_id)
         if report_output:
             self.report_test_output(report, test_id)
-        self.teamcity.testFailed(test_id, message, str(report.longrepr), flowId=test_id)
+
+        diff_error = None
+        try:
+            err_message = str(report.longrepr.reprcrash.message)
+            diff_name = diff_tools.EqualsAssertionError.__name__
+            # There is a string like "foo.bar.DiffError: [serialized_data]"
+            if diff_name in err_message:
+                serialized_data = err_message[err_message.index(diff_name) + len(diff_name) + 1:]
+                diff_error = diff_tools.deserialize_error(serialized_data)
+
+            # AssertionError is patched in py.test, we can try to fetch diff from it
+            if err_message.startswith("AssertionError:"):
+                diff_error = fetch_diff_error_from_message(err_message)
+        except:
+            pass
+
+        if diff_error:
+            # Cut everything after postfix: it is internal view of DiffError
+            strace = str(report.longrepr)
+            data_postfix = "_ _ _ _ _"
+            if data_postfix in strace:
+                strace = strace[0:strace.index(data_postfix)]
+            self.teamcity.testFailed(test_id, diff_error.msg, strace,
+                                     flowId=test_id,
+                                     diff_failed=diff_error
+                                     )
+        else:
+            self.teamcity.testFailed(test_id, message, str(report.longrepr), flowId=test_id)
         self.report_test_finished(test_id, duration)
 
     def report_test_skip(self, test_id, report):

--- a/tests/guinea-pigs/diff_assert.py
+++ b/tests/guinea-pigs/diff_assert.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        self.assertEqual("spam", "eggs", "Fail")
+
+if __name__ == "__main__":
+    from teamcity.unittestpy import TeamcityTestRunner
+    unittest.main(testRunner=TeamcityTestRunner())

--- a/tests/guinea-pigs/diff_assert_error.py
+++ b/tests/guinea-pigs/diff_assert_error.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        assert "spam" == "eggs"

--- a/tests/integration-tests/diff_test_tools.py
+++ b/tests/integration-tests/diff_test_tools.py
@@ -1,0 +1,12 @@
+from service_messages import ServiceMessage
+
+
+SCRIPT = "../diff_assert.py"
+
+
+def expected_messages(test_name):
+    return [
+        ServiceMessage('testStarted', {'name': test_name}),
+        ServiceMessage('testFailed', {'name': test_name, "expected": "spam", "actual": "eggs"}),
+        ServiceMessage('testFinished', {'name': test_name}),
+    ]

--- a/tests/integration-tests/nose_integration_test.py
+++ b/tests/integration-tests/nose_integration_test.py
@@ -5,9 +5,10 @@ import subprocess
 import pytest
 
 import virtual_environments
+from common import get_output_encoding
+from diff_test_tools import SCRIPT, expected_messages
 from service_messages import ServiceMessage, assert_service_messages, match
 from test_util import get_teamcity_messages_root
-from common import get_output_encoding
 
 
 @pytest.fixture(scope='module', params=["nose", "nose==1.2.1", "nose==1.3.1", "nose==1.3.4"])
@@ -110,6 +111,16 @@ def test_deprecated(venv):
             ServiceMessage('testIgnored', {'name': test_name, 'message': 'Deprecated', 'flowId': test_name}),
             ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
         ])
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_diff(venv):
+    output = run(venv, SCRIPT)
+    assert_service_messages(
+        output,
+        [
+            _test_count(venv, 1),
+        ] + expected_messages('diff_assert.FooTest.test_test'))
 
 
 def test_generators(venv):

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 
 import virtual_environments
+from diff_test_tools import expected_messages, SCRIPT
 from service_messages import ServiceMessage, assert_service_messages, has_service_messages
 from common import get_output_encoding
 from test_util import get_teamcity_messages_root
@@ -435,6 +436,28 @@ def test_nose_parameterized(venv):
             ServiceMessage('testFinished', {'name': test2_name}),
         ])
 
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_diff(venv):
+    output = run(venv, SCRIPT)
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+        ] + expected_messages("tests.guinea-pigs.diff_assert.FooTest.test_test"))
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_diff_assert_error(venv):
+    output = run(venv, "../diff_assert_error.py")
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
+            ServiceMessage('testFailed', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test", "expected": "spam", "actual": "eggs"}),
+            ServiceMessage('testFinished', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
+        ])
 
 def test_xfail(venv):
     output = run(venv, 'xfail_test.py')

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -1,14 +1,15 @@
 # coding=utf-8
 import os
-import sys
 import subprocess
+import sys
 
 import pytest
 
 import virtual_environments
+from common import get_output_encoding
+from diff_test_tools import  expected_messages, SCRIPT
 from service_messages import ServiceMessage, assert_service_messages, match
 from test_util import get_teamcity_messages_root
-from common import get_output_encoding
 
 
 @pytest.fixture(scope='module')
@@ -536,6 +537,16 @@ def test_twisted_trial(venv):
         ])
     failed_ms = match(ms, ServiceMessage('testFailed', {'name': test1}))
     assert failed_ms.params['details'].index("5 != 4") > 0
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_diff(venv):
+    output = run_directly(venv, SCRIPT)
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+        ] + expected_messages("__main__.FooTest.test_test"))
 
 
 def run_directly(venv, file):


### PR DESCRIPTION
Support "comparisonFailure" protocol for TC.

This code monkeypatches testEquals forcing it to throw DiffError.

This class either fetched directly from failure or serialized/deserialized
(see diff_tools) to obtain "expected" and "actual" fields.

They are provided to TC (and InteliJ) to display fancy diff viewer.