### PR TITLE
https://github.com/JetBrains/teamcity-messages/issues/123

### DIFF
--- a/teamcity/common.py
+++ b/teamcity/common.py
@@ -115,10 +115,13 @@ def get_class_fullname(something):
     return module + '.' + cls.__name__
 
 
-def convert_error_to_string(err):
+def convert_error_to_string(err, frames_to_skip_from_tail=0):
     try:
         exctype, value, tb = err
-        return ''.join(traceback.format_exception(exctype, value, tb))
+        trace = traceback.format_exception(exctype, value, tb)
+        if frames_to_skip_from_tail:
+            trace = trace[:-frames_to_skip_from_tail]
+        return ''.join(trace)
     except:
         tb = traceback.format_exc()
         return "*FAILED TO GET TRACEBACK*: " + tb

--- a/teamcity/diff_tools.py
+++ b/teamcity/diff_tools.py
@@ -8,10 +8,10 @@ _PRIMITIVES = [int, str, bool]
 if _PY2K:
     # Not available in py3
     # noinspection PyUnresolvedReferences
-    _PRIMITIVES.append(unicode)
+    _PRIMITIVES.append(unicode)  # noqa
     # Not available in py3
     # noinspection PyUnresolvedReferences
-    _STR_F = unicode
+    _STR_F = unicode  # noqa
 else:
     _STR_F = str
 

--- a/teamcity/diff_tools.py
+++ b/teamcity/diff_tools.py
@@ -1,0 +1,82 @@
+import base64
+import pprint
+import sys
+import unittest
+
+_PY2K = sys.version_info < (3,)
+_PRIMITIVES = [int, str, bool]
+if _PY2K:
+    # Not available in py3
+    # noinspection PyUnresolvedReferences
+    _PRIMITIVES.append(unicode)
+    # Not available in py3
+    # noinspection PyUnresolvedReferences
+    _STR_F = unicode
+else:
+    _STR_F = str
+
+
+def patch_unittest_diff():
+    """
+    Patches "assertEquals" to throw DiffError
+    """
+    if sys.version_info < (2, 7):
+        return
+    old = unittest.TestCase.assertEqual
+
+    def _patched_equals(self, first, second, msg=None):
+        if first != second:
+            error = EqualsAssertionError(first, second, msg)
+            if error.is_too_big():
+                old(self, first, second, msg)
+            else:
+                raise error
+
+    unittest.TestCase.assertEqual = _patched_equals
+
+
+def _format_and_convert(val):
+    # No need to pretty-print primitives
+    return val if any(x for x in _PRIMITIVES if isinstance(val, x)) else pprint.pformat(val)
+
+
+class EqualsAssertionError(AssertionError):
+
+    def __init__(self, expected, actual, msg=None, preformated=False):
+        super(AssertionError, self).__init__()
+        self.expected = expected
+        self.actual = actual
+        self.msg = msg
+
+        if not preformated:
+            self.expected = _format_and_convert(self.expected)
+            self.actual = _format_and_convert(self.actual)
+            self.msg = msg if msg else ""
+
+        self.expected = _STR_F(self.expected)
+        self.actual = _STR_F(self.actual)
+
+    def is_too_big(self):
+        return len(self.actual) + len(self.expected) > 10000
+
+    def __str__(self):
+        return self._serialize()
+
+    def __unicode__(self):
+        return self._serialize()
+
+    def _serialize(self):
+        def fix_type(msg):
+            return msg if _PY2K else bytes(str(msg), "utf-8")
+
+        encoded_fields = [base64.b64encode(fix_type(x)) for x in [self.expected, self.actual, self.msg]]
+        if not _PY2K:
+            encoded_fields = [bytes.decode(x) for x in encoded_fields]
+        return "|".join(encoded_fields)
+
+
+def deserialize_error(serialized_message):
+    parts = [base64.b64decode(x) for x in str(serialized_message).split("|")]
+    if not _PY2K:
+        parts = [bytes.decode(x) for x in parts]
+    return EqualsAssertionError(parts[0], parts[1], parts[2], preformated=True)

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -2,13 +2,15 @@
 import sys
 import time
 
+
+
+
 if sys.version_info < (3, ):
     # Python 2
     text_type = unicode  # flake8: noqa
 else:
     # Python 3
     text_type = str
-
 
 # Capture some time functions to allow monkeypatching them in tests
 _time = time.time
@@ -141,8 +143,18 @@ class TeamcityServiceMessages(object):
     def testIgnored(self, testName, message='', flowId=None):
         self.message('testIgnored', name=testName, message=message, flowId=flowId)
 
-    def testFailed(self, testName, message='', details='', flowId=None):
-        self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+    def testFailed(self, testName, message='', details='', flowId=None, comparison_failure=None):
+        if not comparison_failure:
+            self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)
+        else:
+            self.message('testFailed',
+                         name=testName,
+                         message=message,
+                         details=details,
+                         flowId=flowId,
+                         type="comparisonFailure",
+                         actual=comparison_failure.actual,
+                         expected=comparison_failure.expected)
 
     def testStdOut(self, testName, out, flowId=None):
         self.message('testStdOut', name=testName, out=out, flowId=flowId)

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -8,6 +8,8 @@ from teamcity.messages import TeamcityServiceMessages
 from teamcity.common import is_string, get_class_fullname, convert_error_to_string, \
     dump_test_stdout, dump_test_stderr, get_exception_message, to_unicode, FlushingStringIO
 
+from .diff_tools import EqualsAssertionError, patch_unittest_diff
+
 _real_stdout = sys.stdout
 _real_stderr = sys.stderr
 _ERROR_HOLDERS_FQN = ("unittest.suite._ErrorHolder", "unittest2.suite._ErrorHolder")
@@ -189,19 +191,35 @@ class TeamcityTestResult(TestResult):
     def report_fail(self, test, fail_type, err):
         test_id = self.get_test_id(test)
 
+        diff_failed = None
+        try:
+            error = err[1]
+            if isinstance(error, EqualsAssertionError):
+                diff_failed = error
+        except:
+            pass
+
         if is_string(err):
             details = err
         elif get_class_fullname(err) == "twisted.python.failure.Failure":
             details = err.getTraceback()
         else:
-            details = convert_error_to_string(err)
+            frames_to_skip_from_tail = 2 if diff_failed else 0
+            details = convert_error_to_string(err, frames_to_skip_from_tail)
 
         subtest_failures = self.get_subtest_failure(test_id)
         if subtest_failures:
             details = "Failed subtests list: " + subtest_failures + "\n\n" + details.strip()
             details = details.strip()
 
-        self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
+        if diff_failed:
+            self.messages.testFailed(test_id,
+                                     message=diff_failed.msg,
+                                     details=details,
+                                     flowId=test_id,
+                                     comparison_failure=diff_failed)
+        else:
+            self.messages.testFailed(test_id, message=fail_type, details=details, flowId=test_id)
         self.failed_tests.add(test_id)
 
     def startTest(self, test):
@@ -272,6 +290,7 @@ class TeamcityTestRunner(TextTestRunner):
 
     def run(self, test):
         # noinspection PyBroadException
+        patch_unittest_diff()
         try:
             total_tests = test.countTestCases()
             TeamcityServiceMessages(_real_stdout).testCount(total_tests)

--- a/tests/guinea-pigs/diff_assert.py
+++ b/tests/guinea-pigs/diff_assert.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        self.assertEqual("spam", "eggs", "Fail")
+
+if __name__ == "__main__":
+    from teamcity.unittestpy import TeamcityTestRunner
+    unittest.main(testRunner=TeamcityTestRunner())

--- a/tests/guinea-pigs/diff_assert_error.py
+++ b/tests/guinea-pigs/diff_assert_error.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        assert "spam" == "eggs"

--- a/tests/guinea-pigs/diff_assert_error_long.py
+++ b/tests/guinea-pigs/diff_assert_error_long.py
@@ -1,0 +1,2 @@
+def test_test():
+    assert "foo" * 10000 == "spam" * 10, "DDD"

--- a/tests/guinea-pigs/diff_assert_error_nums.py
+++ b/tests/guinea-pigs/diff_assert_error_nums.py
@@ -1,0 +1,6 @@
+import unittest
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        assert 123 == 456

--- a/tests/guinea-pigs/diff_assert_long.py
+++ b/tests/guinea-pigs/diff_assert_long.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+
+class FooTest(unittest.TestCase):
+    def test_test(self):
+        self.assertEqual("spam", "eggs" * 10000, "Fail")
+
+if __name__ == "__main__":
+    from teamcity.unittestpy import TeamcityTestRunner
+    unittest.main(testRunner=TeamcityTestRunner())

--- a/tests/guinea-pigs/diff_toplevel_assert_error.py
+++ b/tests/guinea-pigs/diff_toplevel_assert_error.py
@@ -1,0 +1,2 @@
+def test_test():
+    assert "spam" == "eggs"

--- a/tests/integration-tests/diff_test_tools.py
+++ b/tests/integration-tests/diff_test_tools.py
@@ -1,0 +1,12 @@
+from service_messages import ServiceMessage
+
+
+SCRIPT = "../diff_assert.py"
+
+
+def expected_messages(test_name):
+    return [
+        ServiceMessage('testStarted', {'name': test_name}),
+        ServiceMessage('testFailed', {'name': test_name, "expected": "spam", "actual": "eggs"}),
+        ServiceMessage('testFinished', {'name': test_name}),
+    ]

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -1,14 +1,15 @@
 # coding=utf-8
 import os
-import sys
 import subprocess
+import sys
 
 import pytest
 
 import virtual_environments
+from common import get_output_encoding
+from diff_test_tools import expected_messages, SCRIPT
 from service_messages import ServiceMessage, assert_service_messages, match
 from test_util import get_teamcity_messages_root
-from common import get_output_encoding
 
 
 @pytest.fixture(scope='module')
@@ -536,6 +537,16 @@ def test_twisted_trial(venv):
         ])
     failed_ms = match(ms, ServiceMessage('testFailed', {'name': test1}))
     assert failed_ms.params['details'].index("5 != 4") > 0
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_diff(venv):
+    output = run_directly(venv, SCRIPT)
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+        ] + expected_messages("__main__.FooTest.test_test"))
 
 
 def run_directly(venv, file):


### PR DESCRIPTION
Support "comparisonFailure" protocol for TC.

This code monkeypatches testEquals forcing it to throw DiffError.

This class either fetched directly from failure or serialized/deserialized
(see diff_tools) to obtain "expected" and "actual" fields.

They are provided to TC (and InteliJ) to display fancy diff viewer.