### PR TITLE
Treat empty string in TEAMCITY_VERSION as unset

### DIFF
--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -9,4 +9,4 @@ teamcity_presence_env_var = "TEAMCITY_VERSION"
 
 
 def is_running_under_teamcity():
-    return os.getenv(teamcity_presence_env_var) is not None
+    return bool(os.getenv(teamcity_presence_env_var))


### PR DESCRIPTION
This change makes it easier to proxy environment variable if tests are running inside a docker container.
For example, the command below will work inside and outside of TeamCity.
```shell
docker run -e TEAMCITY_VERSION=${TEAMCITY_VERSION} test-container
```

if `TEAMCITY_VERSION` is not set, inside the docker container `os.getenv("TEAMCITY_VERSION")` is an empty string, the previous version of `is_running_under_teamcity` would return `True`, the update returns `False`.