### PR TITLE
Fix bug with the output argument in TeamcityServiceMessages constructor

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -24,7 +24,9 @@ def escape_value(value):
 
 
 class TeamcityServiceMessages(object):
-    def __init__(self, output=sys.stdout, now=_time, encoding='auto'):
+    def __init__(self, output=None, now=_time, encoding='auto'):
+        if output is None:
+            output = sys.stdout
         if sys.version_info < (3, ) or not hasattr(output, 'buffer'):
             self.output = output
         else:


### PR DESCRIPTION
As you know python's default arguments are evaluated once (not each time the function is called). So the sys.output as a default value in TeamcityServiceMessages constructor disable any ability to modify sys.output during a few calls of [pytest.main](https://docs.pytest.org/en/latest/usage.html#calling-pytest-from-python-code) function.