### PR TITLE
Convert diff objects to text explicitly to prevent cases like https:/…

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -152,7 +152,7 @@ class TeamcityServiceMessages(object):
             diff_message = u"\n{0} != {1}\n".format(comparison_failure.actual, comparison_failure.expected)
             self.message('testFailed',
                          name=testName,
-                         message=message + diff_message,
+                         message=message + text_type(diff_message),
                          details=details,
                          flowId=flowId,
                          type="comparisonFailure",

--- a/tests/guinea-pigs/diff_assert.py
+++ b/tests/guinea-pigs/diff_assert.py
@@ -4,7 +4,7 @@ import unittest
 
 class FooTest(unittest.TestCase):
     def test_test(self):
-        self.assertEqual("spam", "eggs", "Fail")
+        self.assertEqual("spam", ("eggs",), "Fail")
 
 if __name__ == "__main__":
     from teamcity.unittestpy import TeamcityTestRunner

--- a/tests/integration-tests/diff_test_tools.py
+++ b/tests/integration-tests/diff_test_tools.py
@@ -7,6 +7,6 @@ SCRIPT = "../diff_assert.py"
 def expected_messages(test_name):
     return [
         ServiceMessage('testStarted', {'name': test_name}),
-        ServiceMessage('testFailed', {'name': test_name, "expected": "spam", "actual": "eggs"}),
+        ServiceMessage('testFailed', {'name': test_name, "expected": "spam", "actual": "(|'eggs|',)"}),
         ServiceMessage('testFinished', {'name': test_name}),
     ]


### PR DESCRIPTION
…/youtrack.jetbrains.com/issue/PY-28893