### PR TITLE
Provide py.test parameters as metainfo

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -122,8 +122,12 @@ class TeamcityServiceMessages(object):
         import teamcity.context_managers as cm
         return cm.testSuite(self, name=name)
 
-    def testStarted(self, testName, captureStandardOutput=None, flowId=None):
-        self.message('testStarted', name=testName, captureStandardOutput=captureStandardOutput, flowId=flowId)
+    def testStarted(self, testName, captureStandardOutput=None, flowId=None, metainfo=None):
+        """
+
+        :param metainfo: Used to pass any payload from test runner to Intellij. See IDEA-176950
+        """
+        self.message('testStarted', name=testName, captureStandardOutput=captureStandardOutput, flowId=flowId, metainfo=metainfo)
 
     def testFinished(self, testName, testDuration=None, flowId=None):
         if testDuration is not None:

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -177,15 +177,18 @@ class EchoTeamCityMessages(object):
         self.teamcity.testCount(len(items))
 
     def pytest_runtest_logstart(self, nodeid, location):
-        self.ensure_test_start_reported(self.format_test_id(nodeid, location))
+        # test name fetched from location passed as metainfo to PyCharm
+        # it will be used to run specific test using "-k"
+        # See IDEA-176950
+        self.ensure_test_start_reported(self.format_test_id(nodeid, location), location[2])
 
-    def ensure_test_start_reported(self, test_id):
+    def ensure_test_start_reported(self, test_id, metainfo=None):
         if test_id not in self.test_start_reported_mark:
             if self.output_capture_enabled:
                 capture_standard_output = "false"
             else:
                 capture_standard_output = "true"
-            self.teamcity.testStarted(test_id, flowId=test_id, captureStandardOutput=capture_standard_output)
+            self.teamcity.testStarted(test_id, flowId=test_id, captureStandardOutput=capture_standard_output, metainfo=metainfo)
             self.test_start_reported_mark.add(test_id)
 
     def report_has_output(self, report):

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -394,7 +394,7 @@ def test_params(venv):
         output,
         [
             ServiceMessage('testCount', {'count': "3"}),
-            ServiceMessage('testStarted', {'name': test1_name}),
+            ServiceMessage('testStarted', {'name': test1_name, 'metainfo': 'test_eval|[3+5-8|]'}),
             ServiceMessage('testFinished', {'name': test1_name}),
             ServiceMessage('testStarted', {'name': test2_name}),
             ServiceMessage('testFinished', {'name': test2_name}),


### PR DESCRIPTION
This information is used by PyCharm