### PR TITLE
Swap "expected" and "actual" for pytest assert diff to make it closer…

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -25,7 +25,7 @@ from teamcity import diff_tools
 diff_tools.patch_unittest_diff()
 
 
-def fetch_diff_error_from_message(err_message):
+def fetch_diff_error_from_message(err_message, swap_diff):
     line_with_diff = None
     diff_error_message = None
     lines = err_message.split("\n")
@@ -41,7 +41,11 @@ def fetch_diff_error_from_message(err_message):
         parts = [x.strip() for x in line_with_diff.split("==")]
         parts = [s[1:-1] if s.startswith("'") or s.startswith('"') else s for s in parts]
         # Pytest cuts too long lines, no need to check is_too_big
-        return diff_tools.EqualsAssertionError(parts[0], parts[1], diff_error_message)
+        expected, actual = parts[1], parts[0]
+
+        if swap_diff:
+            expected, actual = actual, expected
+        return diff_tools.EqualsAssertionError(expected, actual, diff_error_message)
     else:
         return None
 
@@ -71,6 +75,7 @@ def pytest_addoption(parser):
         kwargs.update({"type": "bool"})
 
     parser.addini("skippassedoutput", **kwargs)
+    parser.addini("swapdiff", **kwargs)
 
 
 def pytest_configure(config):
@@ -89,7 +94,8 @@ def pytest_configure(config):
         config._teamcityReporting = EchoTeamCityMessages(
             output_capture_enabled,
             coverage_controller,
-            skip_passed_output
+            skip_passed_output,
+            bool(config.getini('swapdiff'))
         )
         config.pluginmanager.register(config._teamcityReporting)
 
@@ -110,7 +116,7 @@ def _get_coverage_controller(config):
 
 
 class EchoTeamCityMessages(object):
-    def __init__(self, output_capture_enabled, coverage_controller, skip_passed_output):
+    def __init__(self, output_capture_enabled, coverage_controller, skip_passed_output, swap_diff):
         self.coverage_controller = coverage_controller
         self.output_capture_enabled = output_capture_enabled
         self.skip_passed_output = skip_passed_output
@@ -120,6 +126,7 @@ class EchoTeamCityMessages(object):
 
         self.max_reported_output_size = 1 * 1024 * 1024
         self.reported_output_chunk_size = 50000
+        self.swap_diff = swap_diff
 
     def get_id_from_location(self, location):
         if type(location) is not tuple or len(location) != 3 or not hasattr(location[2], "startswith"):
@@ -258,7 +265,7 @@ class EchoTeamCityMessages(object):
             if err_message.startswith("assert"):
                 err_message = "AssertionError: " + err_message
             if err_message.startswith("AssertionError:"):
-                diff_error = fetch_diff_error_from_message(err_message)
+                diff_error = fetch_diff_error_from_message(err_message, self.swap_diff)
         except Exception:
             pass
 

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -404,7 +404,7 @@ def test_params(venv):
             ServiceMessage('testStarted', {'name': test3_name}),
             ServiceMessage('testFailed', {'name': test3_name,
                                           'message': fix_slashes(
-                                              'tests/guinea-pigs/pytest/params_test.py') + ':3 (test_eval|[6*9-42|])|n42 != 54|n'}),
+                                              'tests/guinea-pigs/pytest/params_test.py') + ':3 (test_eval|[6*9-42|])|n54 != 42|n'}),
             ServiceMessage('testFinished', {'name': test3_name}),
         ])
 
@@ -457,7 +457,7 @@ def test_long_diff(venv):
             ServiceMessage('testCount', {'count': "1"}),
             ServiceMessage('testStarted', {'name': test_name}),
             # "..." inserted by pytest that cuts long lines
-            ServiceMessage('testFailed', {'name': test_name, "expected": "foofoofoofoo...ofoofoofoofoo", "actual": "spamspamspams...mspamspamspam"}),
+            ServiceMessage('testFailed', {'name': test_name, "actual": "foofoofoofoo...ofoofoofoofoo", "expected": "spamspamspams...mspamspamspam"}),
             ServiceMessage('testFinished', {'name': test_name}),
         ])
 
@@ -471,7 +471,7 @@ def test_num_diff(venv):
         [
             ServiceMessage('testCount', {'count': "1"}),
             ServiceMessage('testStarted', {'name': test_name}),
-            ServiceMessage('testFailed', {'name': test_name, "expected": "123", "actual": "456"}),
+            ServiceMessage('testFailed', {'name': test_name, "actual": "123", "expected": "456"}),
             ServiceMessage('testFinished', {'name': test_name}),
         ])
 
@@ -497,6 +497,20 @@ def test_diff_assert_error(venv):
         [
             ServiceMessage('testCount', {'count': "1"}),
             ServiceMessage('testStarted', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
+            ServiceMessage('testFailed', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test", "actual": "spam", "expected": "eggs"}),
+            ServiceMessage('testFinished', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
+        ])
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_swap_diff_assert_error(venv):
+    with make_ini('[pytest]\nswapdiff=true'):
+        output = run(venv, "../diff_assert_error.py")
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
             ServiceMessage('testFailed', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test", "expected": "spam", "actual": "eggs"}),
             ServiceMessage('testFinished', {'name': "tests.guinea-pigs.diff_assert_error.FooTest.test_test"}),
         ])
@@ -510,7 +524,7 @@ def test_diff_top_level_assert_error(venv):
         [
             ServiceMessage('testCount', {'count': "1"}),
             ServiceMessage('testStarted', {'name': "tests.guinea-pigs.diff_toplevel_assert_error.test_test"}),
-            ServiceMessage('testFailed', {'name': "tests.guinea-pigs.diff_toplevel_assert_error.test_test", "expected": "spam", "actual": "eggs"}),
+            ServiceMessage('testFailed', {'name': "tests.guinea-pigs.diff_toplevel_assert_error.test_test", "actual": "spam", "expected": "eggs"}),
             ServiceMessage('testFinished', {'name': "tests.guinea-pigs.diff_toplevel_assert_error.test_test"}),
         ])
 


### PR DESCRIPTION
… to https://docs.pytest.org/en/latest/assert.html  One may use _TC_MESSAGES_SWAP_DIFF env var to switch back