### PR TITLE
meta_info must contain only test name, not class name.

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -202,7 +202,11 @@ class EchoTeamCityMessages(object):
         # test name fetched from location passed as metainfo to PyCharm
         # it will be used to run specific test using "-k"
         # See IDEA-176950
-        self.ensure_test_start_reported(self.format_test_id(nodeid, location), location[2])
+        # We only need method/function name because only it could be used as -k
+        test_name = location[2]
+        if test_name:
+            test_name = str(test_name).split(".")[-1]
+        self.ensure_test_start_reported(self.format_test_id(nodeid, location), test_name)
 
     def ensure_test_start_reported(self, test_id, metainfo=None):
         if test_id not in self.test_start_reported_mark:

--- a/tests/guinea-pigs/pytest/class_with_method.py
+++ b/tests/guinea-pigs/pytest/class_with_method.py
@@ -1,0 +1,6 @@
+import unittest
+
+
+class MyTest(unittest.TestCase):
+    def test_method(self):
+        self.fail("fail")

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -255,6 +255,17 @@ def test_output(venv):
         ])
 
 
+def test_class_with_method(venv):
+    output = run(venv, 'class_with_method.py')
+    assert_service_messages(
+        output,
+        [ServiceMessage('testCount', {'count': "1"})] +
+        [ServiceMessage('testStarted', {"metainfo": "test_method"})] +
+        [ServiceMessage('testFailed', {})] +
+        [ServiceMessage('testFinished', {})]
+    )
+
+
 @pytest.mark.skipif("sys.version_info < (2, 6)", reason="requires Python 2.6+")
 def test_chunked_output(venv):
     output = run(venv, 'chunked_output_test.py')


### PR DESCRIPTION
-k "method" works while -k "Class.method" does not