### PR TITLE
https://github.com/JetBrains/teamcity-messages/issues/196

### DIFF
--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -274,7 +274,10 @@ class TeamcityTestResult(TestResult):
             if subtest_failures:
                 self.report_fail(test, "One or more subtests failed", "")
 
-        time_diff = datetime.datetime.now() - self.test_started_datetime_map[test_id]
+        try:
+            time_diff = datetime.datetime.now() - self.test_started_datetime_map[test_id]
+        except KeyError:
+            time_diff = None
         self.messages.testFinished(test_id, testDuration=time_diff, flowId=test_id)
 
     def printErrors(self):

--- a/tests/guinea-pigs/unittest/test_changes_name.py
+++ b/tests/guinea-pigs/unittest/test_changes_name.py
@@ -1,0 +1,19 @@
+import unittest
+
+from teamcity.unittestpy import TeamcityTestRunner
+
+
+class Foo(unittest.TestCase):
+    a = 1
+
+
+    def test_aa(self): pass
+
+
+    def shortDescription(self):
+        s = str(self.a)
+        self.a += 10
+        return s
+
+
+unittest.main(testRunner=TeamcityTestRunner())

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -20,6 +20,17 @@ def venv(request):
     return virtual_environments.prepare_virtualenv()
 
 
+def test_changes_name(venv):
+    output = run_directly(venv, 'test_changes_name.py')
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': "__main__.Foo.test_aa (1)", 'flowId': "__main__.Foo.test_aa (1)"}),
+            ServiceMessage('testFinished', {'name': "__main__.Foo.test_aa (11)", 'flowId': "__main__.Foo.test_aa (11)"}),
+        ])
+
+
 def test_nested_suits(venv):
     output = run_directly(venv, 'nested_suits.py')
     test_name = '__main__.TestXXX.runTest'


### PR DESCRIPTION
If test changes name in the middle of execution we must ignore its startTime: it is better than KeyError