### PR TITLE
Fix flake8 plugin

### DIFF
--- a/teamcity/flake8_v3_plugin.py
+++ b/teamcity/flake8_v3_plugin.py
@@ -11,18 +11,21 @@ class TeamcityReport(base.BaseFormatter):
     name = 'teamcity-messages'
     version = __version__
 
-    options_added = False
+    @staticmethod
+    def _add_option(parser, name, *args, **kwargs):
+        if all(option.long_option_name != name for option in parser.options):
+            parser.add_option(name, *args, **kwargs)
 
     @classmethod
     def add_options(cls, parser):
-        if not cls.options_added:
-            parser.add_option('--teamcity',
-                              default=is_running_under_teamcity(),
-                              help="Force output of JetBrains TeamCity service messages")
-            parser.add_option('--no-teamcity',
-                              default=False,
-                              help="Disable output of JetBrains TeamCity service messages (even under TeamCity build)")
-            cls.options_added = True
+        cls._add_option(parser,
+                        '--teamcity',
+                        default=is_running_under_teamcity(),
+                        help="Force output of JetBrains TeamCity service messages")
+        cls._add_option(parser,
+                        '--no-teamcity',
+                        default=False,
+                        help="Disable output of JetBrains TeamCity service messages (even under TeamCity build)")
 
     @classmethod
     def parse_options(cls, options):

--- a/tests/guinea-pigs/pytest/flake8_test1.py
+++ b/tests/guinea-pigs/pytest/flake8_test1.py
@@ -1,0 +1,6 @@
+# do not remove unused import, it's a part of the test
+import sys
+
+
+def test_ok():
+    pass

--- a/tests/guinea-pigs/pytest/flake8_test2.py
+++ b/tests/guinea-pigs/pytest/flake8_test2.py
@@ -1,0 +1,6 @@
+# do not remove unused import, it's a part of the test
+import sys
+
+
+def test_ok():
+    pass


### PR DESCRIPTION
We have been unable to use teamcity-messages for testing whenever I
have tried it, due to wanting flake8 output and this consistently
being broken by #190. This PR adds a test to show up the issue and a
fix. Merging after #201 should pass all tests.