### PR TITLE
pytest: fix comparing asserts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ python:
   - "pypy3.5"
 matrix:
   include:
+    - python: "3.5"
+      dist: xenial
+    - python: "pypy3.5"
+      dist: xenial
+    - python: "3.6"
+      dist: xenial
     - python: "3.7"
       dist: xenial
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y sqlite3
 install:
   - pip install flake8 virtualenv pytest
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,14 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
-  - "3.5"
-  - "3.6"
   - "pypy"
-  - "pypy3.5"
 matrix:
   include:
     - python: "3.5"
       dist: xenial
-    - python: "pypy3.5"
-      dist: xenial
     - python: "3.6"
+      dist: xenial
+    - python: "pypy3.5"
       dist: xenial
     - python: "3.7"
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y sqlite3
 install:
   - pip install flake8 virtualenv pytest
 script:

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -318,7 +318,7 @@ class EchoTeamCityMessages(object):
 
     def pytest_assertrepr_compare(self, config, op, left, right):
         if op in ('==', '!='):
-            return ['{} {} {}'.format(pprint.pformat(left), op, pprint.pformat(right))]
+            return ['{0} {1} {2}'.format(pprint.pformat(left), op, pprint.pformat(right))]
 
     def pytest_runtest_logreport(self, report):
         """

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -12,6 +12,7 @@ tests under TeamCity build.
 """
 
 import os
+import pprint
 import sys
 import re
 import traceback
@@ -23,6 +24,13 @@ from teamcity import is_running_under_teamcity
 from teamcity import diff_tools
 
 diff_tools.patch_unittest_diff()
+
+
+def unformat_pytest_explanation(s):
+    """
+    Undo _pytest.assertion.util.format_explanation
+    """
+    return s.replace("\\n", "\n")
 
 
 def fetch_diff_error_from_message(err_message, swap_diff):
@@ -45,6 +53,10 @@ def fetch_diff_error_from_message(err_message, swap_diff):
 
         if swap_diff:
             expected, actual = actual, expected
+
+        expected = unformat_pytest_explanation(expected)
+        actual = unformat_pytest_explanation(actual)
+
         return diff_tools.EqualsAssertionError(expected, actual, diff_error_message)
     else:
         return None
@@ -91,6 +103,7 @@ def pytest_configure(config):
         coverage_controller = _get_coverage_controller(config)
         skip_passed_output = bool(config.getini('skippassedoutput'))
 
+        config.option.verbose = 2  # don't truncate assert explanations
         config._teamcityReporting = EchoTeamCityMessages(
             output_capture_enabled,
             coverage_controller,
@@ -302,6 +315,10 @@ class EchoTeamCityMessages(object):
         self.report_test_output(report, test_id)
         self.teamcity.testIgnored(test_id, reason, flowId=test_id)
         self.report_test_finished(test_id, duration)
+
+    def pytest_assertrepr_compare(self, config, op, left, right):
+        if op in ('==', '!='):
+            return ['{} {} {}'.format(pprint.pformat(left), op, pprint.pformat(right))]
 
     def pytest_runtest_logreport(self, report):
         """

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -480,8 +480,7 @@ def test_long_diff(venv):
         [
             ServiceMessage('testCount', {'count': "1"}),
             ServiceMessage('testStarted', {'name': test_name}),
-            # "..." inserted by pytest that cuts long lines
-            ServiceMessage('testFailed', {'name': test_name, "actual": "foofoofoofoo...ofoofoofoofoo", "expected": "spamspamspams...mspamspamspam"}),
+            ServiceMessage('testFailed', {'name': test_name, "actual": "foo" * 10000, "expected": "spam" * 10}),
             ServiceMessage('testFinished', {'name': test_name}),
         ])
 


### PR DESCRIPTION
The plugin adapts pytest's output of (in)equality assertions to the format expected by PyCharm's comparison tool. However it gets truncated values from pytest which makes the comparison mostly useless. This fix overrides the truncation(s), and further improves the comparison by making it multiline (for comparing complex structures).

- override `pytest_assertrepr_compare` to work around pytest's SafeRepr truncation
- enable verbose mode to disable pytest's truncation of lines
- reverse pytest's escaping of newlines (to enable multiline comparison in PyCharm)