### PR TITLE
use xenial for django's sqlite3>=3.8.3 dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
-  - "3.5"
-  - "3.6"
   - "pypy"
-  - "pypy3.5"
 matrix:
   include:
+    - python: "3.5"
+      dist: xenial
+    - python: "3.6"
+      dist: xenial
+    - python: "pypy3.5"
+      dist: xenial
     - python: "3.7"
       dist: xenial
 install:


### PR DESCRIPTION
Fixing the test breakage.