### PR TITLE
Retry writes to stream on a EAGAIN IOError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /build
 /dist
 /test-result.xml
+/.tox
 
 teamcity_messages.egg-info
 dropin.cache

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+import errno
+from functools import wraps
 import sys
 import time
 
@@ -21,6 +23,24 @@ _quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", '[': '|[', ']': '|]'}
 
 def escape_value(value):
     return "".join(_quote.get(x, x) for x in value)
+
+
+def retry_on_EAGAIN(callable):
+    # self.output seems to be non-blocking when running under teamcity.
+    @wraps(callable)
+    def wrapped(*args, **kwargs):
+        start_time = _time()
+        while True:
+            try:
+                return callable(*args, **kwargs)
+            except IOError as e:
+                if e.errno != errno.EAGAIN:
+                    raise
+                # Give up after a minute.
+                if _time() - start_time > 60:
+                    raise
+                time.sleep(.1)
+    return wrapped
 
 
 class TeamcityServiceMessages(object):
@@ -78,15 +98,15 @@ class TeamcityServiceMessages(object):
         message += ("]\n")
 
         # Python may buffer it for a long time, flushing helps to see real-time result
-        self.output.write(self.encode(message))
-        self.output.flush()
+        retry_on_EAGAIN(self.output.write)(self.encode(message))
+        retry_on_EAGAIN(self.output.flush)()
 
     def _single_value_message(self, messageName, value):
         message = ("##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
 
         # Python may buffer it for a long time, flushing helps to see real-time result
-        self.output.write(self.encode(message))
-        self.output.flush()
+        retry_on_EAGAIN(self.output.write)(self.encode(message))
+        retry_on_EAGAIN(self.output.flush)()
 
     def blockOpened(self, name, flowId=None):
         self.message('blockOpened', name=name, flowId=flowId)


### PR DESCRIPTION
Fixes https://github.com/JetBrains/teamcity-messages/issues/212

Includes regression test.

Normally I'd use a library like https://github.com/rholder/retrying for this, but I wasn't sure if you wanted an extra dependency.