### PR TITLE
Add support for PyLint >= 2.3

### DIFF
--- a/tests/integration-tests/pylint_integration_test.py
+++ b/tests/integration-tests/pylint_integration_test.py
@@ -5,11 +5,11 @@ import virtual_environments
 from service_messages import ServiceMessage, assert_service_messages
 from test_util import run_command
 
-    
+
 if sys.version_info < (3, ):
-    pylint_versions = ['==1.8', '>=1.9']  
+    pylint_versions = ['==1.8', '>=1.9']
 else:
-    pylint_versions = ['==1.8', '==2.2', '>=2.3']  
+    pylint_versions = ['==1.8', '==2.2', '>=2.3']
 
 
 @pytest.fixture(scope='module', params=['pylint' + version for version in pylint_versions], ids=str)
@@ -19,7 +19,7 @@ def venv(request):
 
     * the minimal supported PyLint version is 1.8
     * Python 2.7 is supported up to PyLint 1.9
-    * Python 3.4+ is supported through to the latest 
+    * Python 3.4+ is supported through to the latest
     """
     if sys.version_info < (2, 7) or (3, ) <= sys.version_info < (3, 4):
         pytest.skip("PyLint integration requires Python 2.7 or 3.4+")

--- a/tests/integration-tests/pylint_integration_test.py
+++ b/tests/integration-tests/pylint_integration_test.py
@@ -5,23 +5,26 @@ import virtual_environments
 from service_messages import ServiceMessage, assert_service_messages
 from test_util import run_command
 
+    
+if sys.version_info < (3, ):
+    pylint_versions = ['==1.8', '>=1.9']  
+else:
+    pylint_versions = ['==1.8', '==2.2', '>=2.3']  
 
-pylint_min = '1.8'
-pylint_max = '1.9' if sys.version_info <= (3, ) else '2.1'
 
-
-@pytest.fixture(scope='module', params=[('pylint==' + pylint_min, ), ('pylint==' + pylint_max, )])
+@pytest.fixture(scope='module', params=['pylint' + version for version in pylint_versions], ids=str)
 def venv(request):
     """Virtual environment fixture with PyLint of the minimal and maximal supported version
     for a given python version.
 
-    * Python 2.7 is supported up to PyLint 1.9.
-    * Python 3.4+ is supported through to the latest (2.1)
+    * the minimal supported PyLint version is 1.8
+    * Python 2.7 is supported up to PyLint 1.9
+    * Python 3.4+ is supported through to the latest 
     """
     if sys.version_info < (2, 7) or (3, ) <= sys.version_info < (3, 4):
         pytest.skip("PyLint integration requires Python 2.7 or 3.4+")
 
-    return virtual_environments.prepare_virtualenv(request.param)
+    return virtual_environments.prepare_virtualenv([request.param])
 
 
 def test_sample(venv):


### PR DESCRIPTION
This PR resolves issue #215 by updating the PyLint interface according to changes in version 2.3. It also adds a fallback logic for better stability and extends the integration test to highlight similar issues in the future.