### PR TITLE
#221 subtests are broken when test has name.

### DIFF
--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -152,8 +152,10 @@ class TeamcityTestResult(TestResult):
         if hasattr(_super, "addSubTest"):
             _super.addSubTest(test, subtest, err)
 
-        test_id = self.get_test_id(test)
-        subtest_id = self.get_test_id(subtest)
+        # test_name may contain description which breaks process of fetching id from subtest
+        test_name = self.get_test_id(test)
+        test_id = test.id()
+        subtest_id = subtest.id()
 
         if subtest_id.startswith(test_id):
             # Replace "." -> "_" since '.' is a test hierarchy separator
@@ -165,19 +167,19 @@ class TeamcityTestResult(TestResult):
             block_id = subtest_id
 
         if err is not None:
-            self.add_subtest_failure(test_id, block_id)
+            self.add_subtest_failure(test_name, block_id)
 
             if issubclass(err[0], test.failureException):
-                self.messages.subTestBlockOpened(block_id, subTestResult="Failure", flowId=test_id)
-                self.messages.testStdErr(test_id, out="SubTest failure: %s\n" % convert_error_to_string(err), flowId=test_id)
-                self.messages.blockClosed(block_id, flowId=test_id)
+                self.messages.subTestBlockOpened(block_id, subTestResult="Failure", flowId=test_name)
+                self.messages.testStdErr(test_name, out="SubTest failure: %s\n" % convert_error_to_string(err), flowId=test_name)
+                self.messages.blockClosed(block_id, flowId=test_name)
             else:
-                self.messages.subTestBlockOpened(block_id, subTestResult="Error", flowId=test_id)
-                self.messages.testStdErr(test_id, out="SubTest error: %s\n" % convert_error_to_string(err), flowId=test_id)
-                self.messages.blockClosed(block_id, flowId=test_id)
+                self.messages.subTestBlockOpened(block_id, subTestResult="Error", flowId=test_name)
+                self.messages.testStdErr(test_name, out="SubTest error: %s\n" % convert_error_to_string(err), flowId=test_name)
+                self.messages.blockClosed(block_id, flowId=test_name)
         else:
-            self.messages.subTestBlockOpened(block_id, subTestResult="Success", flowId=test_id)
-            self.messages.blockClosed(block_id, flowId=test_id)
+            self.messages.subTestBlockOpened(block_id, subTestResult="Success", flowId=test_name)
+            self.messages.blockClosed(block_id, flowId=test_name)
 
     def add_subtest_failure(self, test_id, subtest_block_id):
         fail_array = self.subtest_failures.get(test_id, [])

--- a/tests/guinea-pigs/unittest/subtest_named.py
+++ b/tests/guinea-pigs/unittest/subtest_named.py
@@ -1,0 +1,19 @@
+import sys
+from teamcity.unittestpy import TeamcityTestRunner
+
+if sys.version_info < (3, 4):
+    from unittest2 import main, TestCase
+else:
+    from unittest import main, TestCase
+
+
+class NumbersTest(TestCase):
+    def test_even(self):
+        """Test that numbers between 0 and 5 are all even.
+        """
+        for i in range(0, 2):
+            with self.subTest(i=i):
+                self.assertEqual(i % 2, 0)
+
+
+main(testRunner=TeamcityTestRunner)

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -216,6 +216,29 @@ def test_subtest_ok(venv):
 
 
 @pytest.mark.skipif("sys.version_info < (2, 6)", reason="unittest2 requires Python 2.6+")
+def test_subtest_named(venv):
+    if sys.version_info < (3, 4):
+        venv = virtual_environments.prepare_virtualenv(list(venv.packages) + ["unittest2"])
+
+    output = run_directly(venv, 'subtest_named.py')
+    test_id = '__main__.NumbersTest.test_even'
+    test_name = test_id + " (Test that numbers between 0 and 5 are all even_)"
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('blockOpened', {'name': '(i=0)', 'flowId': test_name, 'subTestResult': 'Success'}),
+            ServiceMessage('blockClosed', {'name': '(i=0)', 'flowId': test_name}),
+            ServiceMessage('blockOpened', {'name': '(i=1)', 'flowId': test_name, 'subTestResult': 'Failure'}),
+            ServiceMessage('testStdErr', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('blockClosed', {'name': '(i=1)', 'flowId': test_name}),
+            ServiceMessage('testFailed', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFinished', {'flowId': test_name}),
+        ])
+
+
+@pytest.mark.skipif("sys.version_info < (2, 6)", reason="unittest2 requires Python 2.6+")
 def test_subtest_error(venv):
     if sys.version_info < (3, 4):
         venv = virtual_environments.prepare_virtualenv(list(venv.packages) + ["unittest2"])


### PR DESCRIPTION
We look for test name in subest.
Since id is added between test and description, we can't parse it using substring.

So, we use bare test id (without of description)

see
https://youtrack.jetbrains.com/issue/PY-29614