### PR TITLE
#227: use ``pytest_collection_finish`` to count tests: it doesn't inc…

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -208,8 +208,8 @@ class EchoTeamCityMessages(object):
             return "%s:%s (%s)" % (str(location[0]), str(location[1]), str(location[2]))
         return str(location)
 
-    def pytest_collection_modifyitems(self, session, config, items):
-        self.teamcity.testCount(len(items))
+    def pytest_collection_finish(self, session):
+        self.teamcity.testCount(len(session.items))
 
     def pytest_runtest_logstart(self, nodeid, location):
         # test name fetched from location passed as metainfo to PyCharm

--- a/tests/guinea-pigs/pytest/test_rerun.py
+++ b/tests/guinea-pigs/pytest/test_rerun.py
@@ -1,0 +1,6 @@
+class TestPyTest:
+    def testOne(self):
+        assert True
+
+    def testTwo(self):
+        assert False

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -402,6 +402,21 @@ def test_collect_exception(venv):
     assert ms[2].params["details"].find("runtime error") > 0
 
 
+@pytest.mark.skipif("sys.version_info < (3, 6)", reason="requires Python 3.6+")
+def test_rerun(venv):
+    run(venv, 'test_rerun.py')
+    output = run(venv, 'test_rerun.py', options='--last-failed')
+    test_name = "tests.guinea-pigs.pytest.test_rerun.TestPyTest.testTwo"
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFailed', {'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+
+
 @pytest.mark.skipif("sys.version_info < (2, 7)", reason="requires Python 2.7+")
 def test_collect_skip(venv):
     output = run(venv, 'collect_skip_test.py')


### PR DESCRIPTION
…lude skipped tests.

When launched with ``--last-failed`` pytest reports all tests to ``pytest_collection_modifyitems`` but only enabled (excluding skipped) to ``pytest_collection_finish``. We must use it to report correct number of tests.