### PR TITLE
Do not show redundant stacktrace for diff in unittest.

### DIFF
--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -13,10 +13,11 @@ from test_util import run_command, get_teamcity_messages_root
 
 
 def construct_fixture():
-    params = [('pytest>=4,<5',)]
+    params = []
     if sys.version_info > (3, 0):
-        params.append(('pytest>=5,<6',))
         params.append(('pytest>=6',))
+    else:
+        params.append(('pytest>=4,<5',))
 
     @pytest.fixture(scope='module', params=params)
     def venv(request):


### PR DESCRIPTION
User is only interested in her code, not diff_tools nor unittest code. This is why unittest only reports user file number.

We should do the same