### PR TITLE
Fix teamcity-messages for pylint >= 2.8

### DIFF
--- a/teamcity/pylint_reporter.py
+++ b/teamcity/pylint_reporter.py
@@ -4,7 +4,11 @@ This allows PyLint messages to be processed by TeamCity and displayed on the Cod
 
 import os
 from pylint import reporters
-from pylint.__pkginfo__ import version as pylint_version
+try:
+    from pylint import version as pylint_version
+except ImportError:
+    # Backwards compatibility for pylint < 2.8.0
+    from pylint.__pkginfo__ import version as pylint_version
 
 from teamcity.common import get_class_fullname
 from teamcity import messages


### PR DESCRIPTION
Pylint made changes so `pylint.__pkginfo__.version` does not exist anymore and can be accessed now by `pylint.__pkginfo__.__version__`. This PR makes sure it works for both pylint >= 2.8 and pylint < 2.8.

Related to PyCQA/pylint#4399