### PR TITLE
#243: Support swapdiff as option

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -81,6 +81,7 @@ def pytest_addoption(parser):
                      dest="teamcity", default=0, help="force output of JetBrains TeamCity service messages")
     group._addoption('--no-teamcity', action="count",
                      dest="no_teamcity", default=0, help="disable output of JetBrains TeamCity service messages")
+    parser.addoption('--jb-swapdiff', action="store", dest="swapdiff", default=False, help="Swap actual/expected in diff")
 
     kwargs = {"help": "skip output of passed tests for JetBrains TeamCity service messages"}
     if _is_bool_supported():
@@ -108,7 +109,7 @@ def pytest_configure(config):
             output_capture_enabled,
             coverage_controller,
             skip_passed_output,
-            bool(config.getini('swapdiff'))
+            bool(config.getini('swapdiff') or config.option.swapdiff)
         )
         config.pluginmanager.register(config._teamcityReporting)
 

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -543,6 +543,16 @@ def test_diff_assert_error(venv):
 def test_swap_diff_assert_error(venv):
     with make_ini('[pytest]\nswapdiff=true'):
         output = run(venv, "../diff_assert_error.py")
+    check_swap_diff_result(output)
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_swap_diff_argument_assert_error(venv):
+    output = run(venv, "../diff_assert_error.py", additional_arguments="--jb-swapdiff=True")
+    check_swap_diff_result(output)
+
+
+def check_swap_diff_result(output):
     assert_service_messages(
         output,
         [
@@ -598,7 +608,7 @@ def test_skip_passed_output(venv):
         ])
 
 
-def run(venv, file_names, test=None, options='', set_tc_version=True):
+def run(venv, file_names, test=None, options='', set_tc_version=True, additional_arguments=None):
     if test is not None:
         test_suffix = "::" + test
     else:
@@ -610,4 +620,6 @@ def run(venv, file_names, test=None, options='', set_tc_version=True):
     command = os.path.join(venv.bin, 'py.test') + " " + options + " "
     command += ' '.join(os.path.join('tests', 'guinea-pigs', 'pytest', file_name) + test_suffix
                         for file_name in file_names)
+    if additional_arguments:
+        command += " " + additional_arguments
     return run_command(command, set_tc_version=set_tc_version)


### PR DESCRIPTION
Since we can't now use ini file (this will break pytest support for runs that do not use this plugin) we add option, so user will be able to add/remove it without touching ini file