### PR TITLE
pytest: fix assert diffs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-# Virtual env changed API since 20.0, so we'll use 16 for a while
-virtualenv_version = 'virtualenv==16.7.10'
+virtualenv_version = 'virtualenv==20.7.2'
 if sys.version_info < (3, 7):
     # fix compatible version for slowly obsoleting versions
     tests_require = ['pytest==4.6.9', virtualenv_version]

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -12,6 +12,7 @@ tests under TeamCity build.
 """
 
 import os
+import pprint
 import sys
 import re
 import traceback
@@ -23,7 +24,42 @@ from teamcity import is_running_under_teamcity
 from teamcity import diff_tools
 
 diff_tools.patch_unittest_diff()
-_ASSERTION_FAILURE_KEY = '_teamcity_assertion_failure'
+
+
+def unformat_pytest_explanation(s):
+    """
+    Undo _pytest.assertion.util.format_explanation
+    """
+    return s.replace("\\n", "\n")
+
+
+def fetch_diff_error_from_message(err_message, swap_diff):
+    line_with_diff = None
+    diff_error_message = None
+    lines = err_message.split("\n")
+    if err_message.startswith("AssertionError: assert"):
+        # Everything in one line
+        line_with_diff = lines[0][len("AssertionError: assert "):]
+    elif len(err_message.split("\n")) > 1:
+        err_line = lines[1]
+        line_with_diff = err_line[len("assert "):]
+        diff_error_message = lines[0]
+
+    if line_with_diff and line_with_diff.count("==") == 1:
+        parts = [x.strip() for x in line_with_diff.split("==")]
+        parts = [s[1:-1] if s.startswith("'") or s.startswith('"') else s for s in parts]
+        # Pytest cuts too long lines, no need to check is_too_big
+        expected, actual = parts[1], parts[0]
+
+        if swap_diff:
+            expected, actual = actual, expected
+
+        expected = unformat_pytest_explanation(expected)
+        actual = unformat_pytest_explanation(actual)
+
+        return diff_tools.EqualsAssertionError(expected, actual, diff_error_message)
+    else:
+        return None
 
 
 def _is_bool_supported():
@@ -100,7 +136,6 @@ class EchoTeamCityMessages(object):
 
         self.teamcity = TeamcityServiceMessages()
         self.test_start_reported_mark = set()
-        self.current_test_item = None
 
         self.max_reported_output_size = 1 * 1024 * 1024
         self.reported_output_chunk_size = 50000
@@ -185,10 +220,6 @@ class EchoTeamCityMessages(object):
             test_name = str(test_name).split(".")[-1]
         self.ensure_test_start_reported(self.format_test_id(nodeid, location), test_name)
 
-    def pytest_runtest_protocol(self, item):
-        self.current_test_item = item
-        return None  # continue to next hook
-
     def ensure_test_start_reported(self, test_id, metainfo=None):
         if test_id not in self.test_start_reported_mark:
             if self.output_capture_enabled:
@@ -245,12 +276,13 @@ class EchoTeamCityMessages(object):
                 serialized_data = err_message[err_message.index(diff_name) + len(diff_name) + 1:]
                 diff_error = diff_tools.deserialize_error(serialized_data)
 
-            assertion_tuple = getattr(self.current_test_item, _ASSERTION_FAILURE_KEY, None)
-            if assertion_tuple:
-                op, left, right = assertion_tuple
-                if self.swap_diff:
-                    left, right = right, left
-                diff_error = diff_tools.EqualsAssertionError(expected=right, actual=left)
+            # AssertionError is patched in py.test, we can try to fetch diff from it
+            # In general case message starts with "AssertionError: ", but can also starts with "assert" for top-level
+            # function. To support both cases we unify them
+            if err_message.startswith("assert"):
+                err_message = "AssertionError: " + err_message
+            if err_message.startswith("AssertionError:"):
+                diff_error = fetch_diff_error_from_message(err_message, self.swap_diff)
         except Exception:
             pass
 
@@ -269,7 +301,7 @@ class EchoTeamCityMessages(object):
                 strace = strace[0:strace.index(data_postfix)].strip()
                 if strace.endswith(":") and diff_error.real_exception:
                     strace += " " + type(diff_error.real_exception).__name__
-            self.teamcity.testFailed(test_id, diff_error.msg or message, strace,
+            self.teamcity.testFailed(test_id, diff_error.msg if diff_error.msg else message, strace,
                                      flowId=test_id,
                                      comparison_failure=diff_error
                                      )
@@ -294,7 +326,8 @@ class EchoTeamCityMessages(object):
         self.report_test_finished(test_id, duration)
 
     def pytest_assertrepr_compare(self, config, op, left, right):
-        setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
+        if op in ('==', '!='):
+            return ['{0} {1} {2}'.format(pprint.pformat(left), op, pprint.pformat(right))]
 
     def pytest_runtest_logreport(self, report):
         """

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -12,7 +12,6 @@ tests under TeamCity build.
 """
 
 import os
-import pprint
 import sys
 import re
 import traceback
@@ -24,42 +23,7 @@ from teamcity import is_running_under_teamcity
 from teamcity import diff_tools
 
 diff_tools.patch_unittest_diff()
-
-
-def unformat_pytest_explanation(s):
-    """
-    Undo _pytest.assertion.util.format_explanation
-    """
-    return s.replace("\\n", "\n")
-
-
-def fetch_diff_error_from_message(err_message, swap_diff):
-    line_with_diff = None
-    diff_error_message = None
-    lines = err_message.split("\n")
-    if err_message.startswith("AssertionError: assert"):
-        # Everything in one line
-        line_with_diff = lines[0][len("AssertionError: assert "):]
-    elif len(err_message.split("\n")) > 1:
-        err_line = lines[1]
-        line_with_diff = err_line[len("assert "):]
-        diff_error_message = lines[0]
-
-    if line_with_diff and line_with_diff.count("==") == 1:
-        parts = [x.strip() for x in line_with_diff.split("==")]
-        parts = [s[1:-1] if s.startswith("'") or s.startswith('"') else s for s in parts]
-        # Pytest cuts too long lines, no need to check is_too_big
-        expected, actual = parts[1], parts[0]
-
-        if swap_diff:
-            expected, actual = actual, expected
-
-        expected = unformat_pytest_explanation(expected)
-        actual = unformat_pytest_explanation(actual)
-
-        return diff_tools.EqualsAssertionError(expected, actual, diff_error_message)
-    else:
-        return None
+_ASSERTION_FAILURE_KEY = '_teamcity_assertion_failure'
 
 
 def _is_bool_supported():
@@ -136,6 +100,7 @@ class EchoTeamCityMessages(object):
 
         self.teamcity = TeamcityServiceMessages()
         self.test_start_reported_mark = set()
+        self.current_test_item = None
 
         self.max_reported_output_size = 1 * 1024 * 1024
         self.reported_output_chunk_size = 50000
@@ -220,6 +185,10 @@ class EchoTeamCityMessages(object):
             test_name = str(test_name).split(".")[-1]
         self.ensure_test_start_reported(self.format_test_id(nodeid, location), test_name)
 
+    def pytest_runtest_protocol(self, item):
+        self.current_test_item = item
+        return None  # continue to next hook
+
     def ensure_test_start_reported(self, test_id, metainfo=None):
         if test_id not in self.test_start_reported_mark:
             if self.output_capture_enabled:
@@ -276,13 +245,12 @@ class EchoTeamCityMessages(object):
                 serialized_data = err_message[err_message.index(diff_name) + len(diff_name) + 1:]
                 diff_error = diff_tools.deserialize_error(serialized_data)
 
-            # AssertionError is patched in py.test, we can try to fetch diff from it
-            # In general case message starts with "AssertionError: ", but can also starts with "assert" for top-level
-            # function. To support both cases we unify them
-            if err_message.startswith("assert"):
-                err_message = "AssertionError: " + err_message
-            if err_message.startswith("AssertionError:"):
-                diff_error = fetch_diff_error_from_message(err_message, self.swap_diff)
+            assertion_tuple = getattr(self.current_test_item, _ASSERTION_FAILURE_KEY, None)
+            if assertion_tuple:
+                op, left, right = assertion_tuple
+                if self.swap_diff:
+                    left, right = right, left
+                diff_error = diff_tools.EqualsAssertionError(expected=right, actual=left)
         except Exception:
             pass
 
@@ -301,7 +269,7 @@ class EchoTeamCityMessages(object):
                 strace = strace[0:strace.index(data_postfix)].strip()
                 if strace.endswith(":") and diff_error.real_exception:
                     strace += " " + type(diff_error.real_exception).__name__
-            self.teamcity.testFailed(test_id, diff_error.msg if diff_error.msg else message, strace,
+            self.teamcity.testFailed(test_id, diff_error.msg or message, strace,
                                      flowId=test_id,
                                      comparison_failure=diff_error
                                      )
@@ -326,8 +294,7 @@ class EchoTeamCityMessages(object):
         self.report_test_finished(test_id, duration)
 
     def pytest_assertrepr_compare(self, config, op, left, right):
-        if op in ('==', '!='):
-            return ['{0} {1} {2}'.format(pprint.pformat(left), op, pprint.pformat(right))]
+        setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
 
     def pytest_runtest_logreport(self, report):
         """

--- a/tests/guinea-pigs/diff_assert_error_multiline.py
+++ b/tests/guinea-pigs/diff_assert_error_multiline.py
@@ -1,0 +1,2 @@
+def test_test():
+    assert "a\n" * 30 == "b\n" * 30

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -500,6 +500,20 @@ def test_long_diff(venv):
 
 
 @pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
+def test_multiline_diff(venv):
+    output = run(venv, "../diff_assert_error_multiline.py")
+    test_name = 'tests.guinea-pigs.diff_assert_error_multiline.test_test'
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name}),
+            ServiceMessage('testFailed', {'name': test_name, "actual": "a|n" * 30, "expected": "b|n" * 30}),
+            ServiceMessage('testFinished', {'name': test_name}),
+        ])
+
+
+@pytest.mark.skipif("sys.version_info < (2, 7) ", reason="requires Python 2.7")
 def test_num_diff(venv):
     output = run(venv, "../diff_assert_error_nums.py")
     test_name = 'tests.guinea-pigs.diff_assert_error_nums.FooTest.test_test'

--- a/tests/integration-tests/virtual_environments.py
+++ b/tests/integration-tests/virtual_environments.py
@@ -72,7 +72,7 @@ def prepare_virtualenv(packages=()):
         if os.path.exists(vdir):
             shutil.rmtree(vdir)
 
-        virtualenv.create_environment(vdir)
+        virtualenv.cli_run([vdir])
         # Update for newly created environment
         if sys.version_info >= (2, 7):
             _call([vpython, "-m", "pip", "install", "--upgrade", "pip", "setuptools"], env=env, cwd=get_teamcity_messages_root())


### PR DESCRIPTION
In #210 I've tried to capture comparisons in pytest assertions in order to propagate them as diffs. The change in #210 attempts to reverse the formatting changes done by pytest, but it's not reliable and still leads to wrong behavior for multi-line changes.

A simpler and more reliable approach is implemented here. We stash the assertions within the assertion handler, and then retrieve them in `pytest_runtest_logreport`. This fixes handling of multiline comparisons. I've been using this version in my PyCharm development for months now, and it's been providing me flawless diffs in all kinds of complex cases.

P.S. The introduction of the "global" variable `current_test_item` is a little messy but pytest doesn't provide a nicer way -- see discussion in https://github.com/pytest-dev/pytest/issues/8740. If you look at the underlying pytest implementation (`util._reprcompare`), you'd see it's effectively assuming one test at a time.