### PR TITLE
PyTest: report crashing tests as failed

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -352,7 +352,8 @@ class EchoTeamCityMessages(object):
                     self.report_test_output(report, test_id)
                     self.teamcity.blockClosed(block_name, flowId=test_id)
         elif report.failed:
-            if report.when == 'call':
+            if report.when == 'call' or report.when == '???':
+                # ??? indicates the test crashed when run in a subprocess (due to --forked, --boxed or -n)
                 self.report_test_failure(test_id, report)
             elif report.when == 'setup':
                 if self.report_has_output(report):


### PR DESCRIPTION
This change ensures that a test which crashes is reported to TeamCity as failed.

When using PyTest with the `pytest-xdist` plugin and one of the `--forked`, `--boxed` or `-n` options, tests will execute in Python subprocesses, which means individual tests can crash without crashing the main PyTest process. In case of a crash, the `pytest_runtest_logreport` hook is called with `report.failed == True` and `report.when == '???'` (undocumented behaviour). This PR modifies the TeamCity PyTest plugin to handle this case.

Example output:

    ##teamcity[testFailed timestamp='2021-08-10T14:39:37.427' details=':-1: running the test CRASHED with signal 11' flowId='Test.test_crash.test_fail' message='Test/test_crash.py:0 (test_fail)' name='Test.test_crash.test_fail']
