### PR TITLE
Make teamcity-message compatibility with pylint >=2.12

### DIFF
--- a/teamcity/pylint_reporter.py
+++ b/teamcity/pylint_reporter.py
@@ -84,7 +84,12 @@ class TeamCityReporter(reporters.BaseReporter):
     def display_reports(self, layout):
         """Issues the final PyLint score as a TeamCity build statistic value"""
         try:
-            score = self.linter.stats['global_note']
+            stats = self.linter.stats
+            score = getattr(stats, 'global_note', None)
+
+            # Backwards compatibility for pylint version <2.12
+            if score is None:
+                score = stats['global_note']
         except (AttributeError, KeyError):
             pass
         else:


### PR DESCRIPTION
Currently it's not possible to update to pylint >=2.12 because teamcity-reporter fails with this version:

```
Traceback (most recent call last):
  File "/.venv/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/.venv/lib/python3.6/site-packages/pylint/__init__.py", line 24, in run_pylint
    PylintRun(sys.argv[1:])
  File "/.venv/lib/python3.6/site-packages/pylint/lint/run.py", line 399, in __init__
    score_value = linter.generate_reports()
  File "/.venv/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 1287, in generate_reports
    score_value = self._report_evaluation()
  File "/.venv/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 1329, in _report_evaluation
    self.reporter.display_reports(sect)
  File "/.venv/lib/python3.6/site-packages/teamcity/pylint_reporter.py", line 87, in display_reports
    score = self.linter.stats['global_note']
TypeError: 'LinterStats' object is not subscriptable
```

This change will fix that issue and makes it work for pylint >=2.12 while making sure it keeps working with older versions too.

Related to https://github.com/PyCQA/pylint/issues/5426