### PR TITLE
Check for old Reporter class after importing it

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -345,6 +345,8 @@ class EchoTeamCityMessages(object):
             def __init__(self, coverage, config):
                 try:
                     from coverage.report import Reporter
+                    if not hasattr(Reporter, "find_file_reporters"):
+                        raise ImportError("Wrong Reporter class, probably the Protocol version from coverage >= 7.0.2")
                 except ImportError:
                     # Support for coverage >= 5.0.1.
                     from coverage.report import get_analysis_to_report


### PR DESCRIPTION
With coverage 7.0.2 a new Reporter class has been introduced, that is incompatible to the one from pre 5.x

Should fix #273 