### PR TITLE
add service message testMetadata

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -183,6 +183,10 @@ class TeamcityServiceMessages(object):
                          actual=comparison_failure.actual,
                          expected=comparison_failure.expected)
 
+    def testMetadata(self, testName, name, value='', type='', flowId=None):
+        # https://www.jetbrains.com/help/teamcity/reporting-test-metadata.html#Reporting+Additional+Test+Data
+        self.message('testMetadata', name=name, testName=testName, value=value, type=type, flowId=flowId)
+
     def testStdOut(self, testName, out, flowId=None):
         self.message('testStdOut', name=testName, out=out, flowId=flowId)
 


### PR DESCRIPTION
This PR adds `testMetadata` service message as documented in https://www.jetbrains.com/help/teamcity/reporting-test-metadata.html#Reporting+Additional+Test+Data

I haven't included any tests as I'm not sure what are the guidelines are for those (no CONTRIBUTING.md or references in README).

Let me know if anything is required

Note: currently using this in a project by subclassing the original `TeamcityServiceMessages`