### PR TITLE
Fix `setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))` error

### DIFF
--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -282,7 +282,8 @@ class EchoTeamCityMessages(object):
         self.report_test_finished(test_id, duration)
 
     def pytest_assertrepr_compare(self, config, op, left, right):
-        setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
+        if hasattr(self.current_test_item, _ASSERTION_FAILURE_KEY):
+            setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
 
     def pytest_runtest_logreport(self, report):
         """


### PR DESCRIPTION
Hello, in my PyCharm IDE I frequently get an error:
```
self = <teamcity.pytest_plugin.EchoTeamCityMessages object at 0x130e3d810>
config = <_pytest.config.Config object at 0x10a15c520>, op = '==', left = 2
right = 0

    def pytest_assertrepr_compare(self, config, op, left, right):
>       setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
E       AttributeError: 'NoneType' object has no attribute '_teamcity_assertion_failure'
```
As do many other people at my company who use pycharm. We have manually edit the code in the PyCharm environment to comment out the `setattr` call, then whenever we get a pycharm update we have to do it again. It's a massive hassle, and I'd like to fix this. 

Unfortunately, I have no way to test this 😢 
