### PR TITLE
fix #285 remove deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
there is already ...

```
license='Apache 2.0',
```