### PR TITLE
skip `test_pytest_flake8_v1_1` on Python 3.12 - `flake8==4.0.1` doesn't support it

### DIFF
--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -95,7 +95,7 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
         internal_test_pytest_flake8(venv_with_pylint, "tests.guinea-pigs.pytest.{}.FLAKE8")
 
 
-    @pytest.mark.skipif("sys.version_info < (3, 7)", reason="requires Python 3.7+")
+    @pytest.mark.skipif("sys.version_info < (3, 7) or sys.version_info >= (3, 12)", reason="requires Python 3.7+")
     def test_pytest_flake8_v1_1(venv):
         # Use flake8 < 5 as there is an issue in pytest-flake8 package:
         # https://github.com/tholo/pytest-flake8/issues/87


### PR DESCRIPTION
Test [tests.integration-tests.pytest_integration_test.test_pytest_flake8_v1_1(venv0)](https://teamcity.jetbrains.com/test/-8789287020948915173?currentProjectId=TeamCityPluginsByJetBrains_TeamCityPythonReporter) fails on Python 3.12 as the test has `flake8==4.0.1` pinned, which is not compatible with Python 3.12.

If you'd like to preserve this test vs. `flake8==4.0.1` - the test has to be skipped on Python >=3.12 (this PR).

I suggest adding another test with unpinned `flake8`, though it will have its own issues, so I decided not to include it here. I can do it in a separate PR if you'd like to have it.