### PR TITLE
Updating troves for 3.11/3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Testing'
     ],
     url="https://github.com/JetBrains/teamcity-messages",


### PR DESCRIPTION
We're already using this package on 3.11 and 3.12.  It should pass CI, but ideally marking it will solve of *our* satsolver issues.