### PR TITLE
Custom output handlers + improvements for non-buffered mode

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -1,9 +1,8 @@
 # coding=utf-8
-import errno
-from functools import wraps
 import sys
 import time
 
+from teamcity.output import TeamCityMessagesPrinter
 
 if sys.version_info < (3, ):
     # Python 2
@@ -25,32 +24,11 @@ def escape_value(value):
     return "".join(_quote.get(x, x) for x in value)
 
 
-def retry_on_EAGAIN(callable):
-    # self.output seems to be non-blocking when running under teamcity.
-    @wraps(callable)
-    def wrapped(*args, **kwargs):
-        start_time = _time()
-        while True:
-            try:
-                return callable(*args, **kwargs)
-            except IOError as e:
-                if e.errno != errno.EAGAIN:
-                    raise
-                # Give up after a minute.
-                if _time() - start_time > 60:
-                    raise
-                time.sleep(.1)
-    return wrapped
-
-
 class TeamcityServiceMessages(object):
-    def __init__(self, output=None, now=_time, encoding='auto'):
-        if output is None:
-            output = sys.stdout
-        if sys.version_info < (3, ) or not hasattr(output, 'buffer'):
-            self.output = output
-        else:
-            self.output = output.buffer
+    def __init__(self, output=None, now=_time, encoding='auto', output_handler=None):
+        if output_handler is None:
+            output_handler = TeamCityMessagesPrinter(output)
+        self.output_handler = output_handler
         self.now = now
 
         if encoding and encoding != 'auto':
@@ -97,16 +75,12 @@ class TeamcityServiceMessages(object):
 
         message += ("]\n")
 
-        # Python may buffer it for a long time, flushing helps to see real-time result
-        retry_on_EAGAIN(self.output.write)(self.encode(message))
-        retry_on_EAGAIN(self.output.flush)()
+        self.output_handler.send_message(self.encode(message))
 
     def _single_value_message(self, messageName, value):
         message = ("##teamcity[%s '%s']\n" % (messageName, self.escapeValue(value)))
 
-        # Python may buffer it for a long time, flushing helps to see real-time result
-        retry_on_EAGAIN(self.output.write)(self.encode(message))
-        retry_on_EAGAIN(self.output.flush)()
+        self.output_handler.send_message(self.encode(message))
 
     def blockOpened(self, name, flowId=None):
         self.message('blockOpened', name=name, flowId=flowId)

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -169,6 +169,9 @@ class TeamcityServiceMessages(object):
     def testIgnored(self, testName, message='', flowId=None):
         self.message('testIgnored', name=testName, message=message, flowId=flowId)
 
+    def testStopped(self, testName, message='', flowId=None):
+        self.message('testIgnored', name=testName, message=message, flowId=flowId, stopped="true")
+
     def testFailed(self, testName, message='', details='', flowId=None, comparison_failure=None):
         if not comparison_failure:
             self.message('testFailed', name=testName, message=message, details=details, flowId=flowId)

--- a/teamcity/output.py
+++ b/teamcity/output.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+import errno
+import sys
+from functools import wraps
+import time
+
+# Capture some time functions to allow monkeypatching them in tests
+_time = time.time
+_stderr = sys.stderr
+
+
+class TeamCityMessagesPrinter(object):
+    def __init__(self, output=None, context_manager=None):
+        if output is None:
+            output = sys.stdout
+        if sys.version_info < (3,) or not hasattr(output, 'buffer'):
+            self.output = output
+        else:
+            self.output = output.buffer
+        # context manager can be set for testing frameworks such as pytest, which may redirect
+        # normal output, to temporarily disable redirection for Teamcity messages
+        self.context_manager = context_manager
+
+    def send_message(self, message):
+        if self.context_manager:
+            with self.context_manager():
+                self._output(message)
+        else:
+            self._output(message)
+
+    def _output(self, message):
+        # Python may buffer it for a long time, flushing helps to see real-time result
+        retry_on_EAGAIN(self.output.write)(message)
+        retry_on_EAGAIN(self.output.flush)()
+
+
+def retry_on_EAGAIN(callable):
+    # output seems to be non-blocking when running under teamcity.
+    @wraps(callable)
+    def wrapped(*args, **kwargs):
+        start_time = _time()
+        while True:
+            try:
+                return callable(*args, **kwargs)
+            except IOError as e:
+                if e.errno != errno.EAGAIN:
+                    raise
+                # Give up after a minute.
+                if _time() - start_time > 60:
+                    raise
+                time.sleep(.1)
+
+    return wrapped

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -23,6 +23,7 @@ from teamcity import diff_tools
 from teamcity import is_running_under_teamcity
 from teamcity.common import convert_error_to_string, dump_test_stderr, dump_test_stdout
 from teamcity.messages import TeamcityServiceMessages
+from teamcity.output import TeamCityMessagesPrinter
 
 diff_tools.patch_unittest_diff()
 _ASSERTION_FAILURE_KEY = '_teamcity_assertion_failure'
@@ -60,6 +61,8 @@ def pytest_configure(config):
         config.option.verbose = 2  # don't truncate assert explanations
         config._teamcityReporting = EchoTeamCityMessages(
             output_capture_enabled,
+            # never write tc messages into buffered output
+            getattr(config.pluginmanager.getplugin('capturemanager'), 'global_and_fixture_disabled'),
             coverage_controller,
             skip_passed_output,
             bool(config.getini('swapdiff') or config.option.swapdiff)
@@ -83,12 +86,13 @@ def _get_coverage_controller(config):
 
 
 class EchoTeamCityMessages(object):
-    def __init__(self, output_capture_enabled, coverage_controller, skip_passed_output, swap_diff):
+    def __init__(self, output_capture_enabled, context_manager, coverage_controller, skip_passed_output, swap_diff):
         self.coverage_controller = coverage_controller
         self.output_capture_enabled = output_capture_enabled
         self.skip_passed_output = skip_passed_output
 
-        self.teamcity = TeamcityServiceMessages()
+        output_handler = TeamCityMessagesPrinter(context_manager=context_manager)
+        self.teamcity = TeamcityServiceMessages(output_handler=output_handler)
         self.test_start_reported_mark = set()
         self.current_test_item = None
 

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import sys
-from unittest import TestResult, TextTestRunner
+from unittest import TextTestResult, TextTestRunner
 import datetime
 import re
 
@@ -15,12 +15,11 @@ _real_stderr = sys.stderr
 _ERROR_HOLDERS_FQN = ("unittest.suite._ErrorHolder", "unittest2.suite._ErrorHolder")
 
 
-class TeamcityTestResult(TestResult):
+class TeamcityTestResult(TextTestResult):
     separator2 = "\n"
 
-    # noinspection PyUnusedLocal
-    def __init__(self, stream=_real_stdout, descriptions=None, verbosity=None):
-        super(TeamcityTestResult, self).__init__()
+    def __init__(self, stream=_real_stdout, descriptions=None, verbosity=0):
+        super(TeamcityTestResult, self).__init__(stream, descriptions, verbosity)
 
         # Some code may ask for self.failfast, see unittest2.case.TestCase.subTest
         self.failfast = getattr(self, "failfast", False)

--- a/teamcity/unittestpy.py
+++ b/teamcity/unittestpy.py
@@ -276,6 +276,10 @@ class TeamcityTestResult(TextTestResult):
             if subtest_failures:
                 self.report_fail(test, "One or more subtests failed", "")
 
+        if sys.exc_info()[0] is not None:
+            # test was interrupted (e.g., SIGINT)
+            self.messages.testStopped(test_id, flowId=test_id)
+
         try:
             time_diff = datetime.datetime.now() - self.test_started_datetime_map[test_id]
         except KeyError:

--- a/tests/guinea-pigs/pytest/keyboard_interrupt_test.py
+++ b/tests/guinea-pigs/pytest/keyboard_interrupt_test.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+
+
+def test_with_interrupt():
+    raise KeyboardInterrupt()

--- a/tests/guinea-pigs/unittest/keyboard_interrupt.py
+++ b/tests/guinea-pigs/unittest/keyboard_interrupt.py
@@ -1,0 +1,11 @@
+import unittest
+
+from teamcity.unittestpy import TeamcityTestRunner
+
+
+class TestKeyboardInterrupt(unittest.TestCase):
+    def runTest(self):
+        raise KeyboardInterrupt()
+
+
+TeamcityTestRunner().run(TestKeyboardInterrupt())

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -634,6 +634,21 @@ def test_skip_passed_output(venv):
         ])
 
 
+def test_keyboard_interrupt(venv):
+    output = run(venv, 'keyboard_interrupt_test.py')
+
+    test_name = 'tests.guinea-pigs.pytest.keyboard_interrupt_test.test_with_interrupt'
+
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name, 'captureStandardOutput': 'false'}),
+            ServiceMessage('testIgnored', {'name': test_name, 'flowId': test_name, 'stopped': 'true'}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name})
+        ])
+
+
 def run(venv, file_names, test=None, options='', set_tc_version=True, additional_arguments=None, env=None):
     if test is not None:
         test_suffix = "::" + test

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -589,6 +589,13 @@ def test_equals_processed_correctly(venv):
     assert output and "testFailed" not in output
 
 
+def test_verbose_output(venv):
+    command = os.path.join(venv.bin, 'python') + " -m unittest --quiet --verbose " + os.path.join('tests', 'guinea-pigs', 'unittest', 'assert.py')
+    output = run_command(command)
+
+    assert "... FAIL" in output
+
+
 def run_directly(venv, file):
     command = os.path.join(venv.bin, 'python') + " " + os.path.join('tests', 'guinea-pigs', 'unittest', file)
     return run_command(command)

--- a/tests/integration-tests/unittest_integration_test.py
+++ b/tests/integration-tests/unittest_integration_test.py
@@ -596,6 +596,18 @@ def test_verbose_output(venv):
     assert "... FAIL" in output
 
 
+def test_keyboard_interrupt(venv):
+    output = run_directly(venv, 'keyboard_interrupt.py')
+    ms = assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': '__main__.TestKeyboardInterrupt.runTest'}),
+            ServiceMessage('testIgnored', {'name': '__main__.TestKeyboardInterrupt.runTest', 'stopped': 'true'}),
+            ServiceMessage('testFinished', {'name': '__main__.TestKeyboardInterrupt.runTest'}),
+        ])
+
+
 def run_directly(venv, file):
     command = os.path.join(venv.bin, 'python') + " " + os.path.join('tests', 'guinea-pigs', 'unittest', file)
     return run_command(command)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -440,3 +440,12 @@ def test_mismatched_encoding(encoding, is_message_encodable):
         expected_value = value.encode('unicode-escape').decode('latin-1')
 
     assert stream.getvalue() == "##teamcity[%s timestamp='2000-11-02T10:23:01.556']\n" % expected_value
+
+
+def test_test_stopped():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.testStopped(testName='only a test', message='some message')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testIgnored timestamp='2000-11-02T10:23:01.556' message='some message' name='only a test' stopped='true']
+        """).strip().encode('utf-8')

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -1,4 +1,5 @@
 from teamcity.messages import TeamcityServiceMessages, escape_value
+from teamcity.output import TeamCityMessagesPrinter
 
 from datetime import datetime
 import errno
@@ -449,3 +450,16 @@ def test_test_stopped():
     assert stream.observed_output.strip() == textwrap.dedent("""\
         ##teamcity[testIgnored timestamp='2000-11-02T10:23:01.556' message='some message' name='only a test' stopped='true']
         """).strip().encode('utf-8')
+
+
+class CustomOutputHandler(TeamCityMessagesPrinter):
+    def send_message(self, message):
+        self._output(b'Fake!')
+
+
+def test_custom_output_handler():
+    stream = StreamStub()
+    output_handler = CustomOutputHandler(output=stream)
+    messages = TeamcityServiceMessages(now=lambda: fixed_date, output_handler=output_handler)
+    messages.testStarted('only a test')
+    assert stream.observed_output.strip() == 'Fake!'.encode('utf-8')


### PR DESCRIPTION
This PR introduces a set of changes aimed at supporting the use of this library in environments where TeamCity messages are sent over an alternative channel (e.g., Unix domain sockets) instead of stdout, while preserving CLI-style test output.

Key changes:
- Support for custom output handlers in the TeamcityServiceMessages class
- Fixes to ensure unittest verbosity settings are correctly propagated
- Improved handling of interactive test interruptions (e.g., Ctrl+C, KeyboardInterrupt)