### PR TITLE
Add TeamcityServiceMessages.buildNumber() method

### DIFF
--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -188,6 +188,9 @@ class TeamcityServiceMessages(object):
     def buildStatus(self, status, text):
         self.message('buildStatus', status=status, text=text)
 
+    def buildNumber(self, value):
+        self._single_value_message('buildNumber', value)
+
     def setParameter(self, name, value):
         self.message('setParameter', name=name, value=value)
 

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -247,6 +247,15 @@ def test_build_status():
         """).strip().encode('utf-8')
 
 
+def test_build_number():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.buildNumber("1.2.3_{build.number}-ent")
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[buildNumber '1.2.3_{build.number}-ent']
+        """).strip().encode('utf-8')
+
+
 def test_set_parameter():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)


### PR DESCRIPTION
Support for setting a custom build number as per https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Number