### PR TITLE
Improve pytest captured output reporting

### DIFF
--- a/teamcity/common.py
+++ b/teamcity/common.py
@@ -73,6 +73,11 @@ def dump_test_stdout(messages, test_id, flow_id, data):
         messages.testStdOut(test_id, chunk, flowId=flow_id)
 
 
+def dump_test_log(messages, test_id, flow_id, data):
+    for chunk in split_output(limit_output(data)):
+        messages.message('testLog', name=test_id, out=chunk, flowId=flow_id)
+
+
 def dump_test_stderr(messages, test_id, flow_id, data):
     for chunk in split_output(limit_output(data)):
         messages.testStdErr(test_id, chunk, flowId=flow_id)

--- a/teamcity/pytest_plugin.py
+++ b/teamcity/pytest_plugin.py
@@ -21,12 +21,24 @@ import pytest
 
 from teamcity import diff_tools
 from teamcity import is_running_under_teamcity
-from teamcity.common import convert_error_to_string, dump_test_stderr, dump_test_stdout
+from teamcity.common import convert_error_to_string, dump_test_log, dump_test_stderr, dump_test_stdout
 from teamcity.messages import TeamcityServiceMessages
 from teamcity.output import TeamCityMessagesPrinter
 
 diff_tools.patch_unittest_diff()
 _ASSERTION_FAILURE_KEY = '_teamcity_assertion_failure'
+_skip_passed_output_default = None
+_report_logs_as_test_log = False
+
+
+def set_skip_passed_output_default(value):
+    global _skip_passed_output_default
+    _skip_passed_output_default = value
+
+
+def set_report_logs_as_test_log(value):
+    global _report_logs_as_test_log
+    _report_logs_as_test_log = value
 
 
 def pytest_addoption(parser):
@@ -38,11 +50,11 @@ def pytest_addoption(parser):
                      dest="no_teamcity", default=0, help="disable output of JetBrains TeamCity service messages")
     parser.addoption('--jb-swapdiff', action="store_true", dest="swapdiff", default=False, help="Swap actual/expected in diff")
 
-    kwargs = {"help": "skip output of passed tests for JetBrains TeamCity service messages"}
-    kwargs.update({"type": "bool"})
-
-    parser.addini("skippassedoutput", **kwargs)
-    parser.addini("swapdiff", **kwargs)
+    skip_passed_output = {"type": "bool"}
+    if _skip_passed_output_default is not None:
+        skip_passed_output["default"] = _skip_passed_output_default
+    parser.addini("skippassedoutput", help="skip output of passed tests for JetBrains TeamCity service messages", **skip_passed_output)
+    parser.addini("swapdiff", help="Swap actual/expected in diff", type="bool")
 
 
 def pytest_configure(config):
@@ -65,7 +77,8 @@ def pytest_configure(config):
             getattr(config.pluginmanager.getplugin('capturemanager'), 'global_and_fixture_disabled'),
             coverage_controller,
             skip_passed_output,
-            bool(config.getini('swapdiff') or config.option.swapdiff)
+            bool(config.getini('swapdiff') or config.option.swapdiff),
+            _report_logs_as_test_log
         )
         config.pluginmanager.register(config._teamcityReporting)
 
@@ -86,10 +99,12 @@ def _get_coverage_controller(config):
 
 
 class EchoTeamCityMessages(object):
-    def __init__(self, output_capture_enabled, context_manager, coverage_controller, skip_passed_output, swap_diff):
+    def __init__(self, output_capture_enabled, context_manager, coverage_controller, skip_passed_output, swap_diff,
+                 report_logs_as_test_log):
         self.coverage_controller = coverage_controller
         self.output_capture_enabled = output_capture_enabled
         self.skip_passed_output = skip_passed_output
+        self.report_logs_as_test_log = report_logs_as_test_log
 
         output_handler = TeamCityMessagesPrinter(context_manager=context_manager)
         self.teamcity = TeamcityServiceMessages(output_handler=output_handler)
@@ -185,6 +200,7 @@ class EchoTeamCityMessages(object):
             self.rootdir = str(session.config.rootdir)
         self.teamcity.testCount(len(session.items))
 
+    @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_logstart(self, nodeid, location):
         # test name fetched from location passed as metainfo to PyCharm
         # it will be used to run specific test
@@ -212,9 +228,12 @@ class EchoTeamCityMessages(object):
 
     def report_has_output(self, report):
         for (secname, data) in report.sections:
-            if report.when in secname and ('stdout' in secname or 'stderr' in secname):
+            if report.when in secname and ('stdout' in secname or 'stderr' in secname or ('log' in secname and self.report_logs_as_test_log)):
                 return True
         return False
+
+    def report_output_separator(self):
+        self.teamcity.output_handler.send_message(self.teamcity.encode("\n"))
 
     def report_test_output(self, report, test_id):
         for (secname, data) in report.sections:
@@ -227,9 +246,20 @@ class EchoTeamCityMessages(object):
                 continue
 
             if 'stdout' in secname:
+                self.report_output_separator()
                 dump_test_stdout(self.teamcity, test_id, test_id, data)
             elif 'stderr' in secname:
+                self.report_output_separator()
                 dump_test_stderr(self.teamcity, test_id, test_id, data)
+            elif 'log' in secname:
+                self.report_test_log(test_id, data)
+
+    def report_test_log(self, test_id, data):
+        if not self.report_logs_as_test_log:
+            return
+
+        self.report_output_separator()
+        dump_test_log(self.teamcity, test_id, test_id, data)
 
     def report_test_finished(self, test_id, duration=None):
         self.teamcity.testFinished(test_id, testDuration=duration, flowId=test_id)
@@ -314,6 +344,7 @@ class EchoTeamCityMessages(object):
     def pytest_assertrepr_compare(self, config, op, left, right):
         setattr(self.current_test_item, _ASSERTION_FAILURE_KEY, (op, left, right))
 
+    @pytest.hookimpl(trylast=True)
     def pytest_runtest_logreport(self, report):
         """
         :type report: _pytest.runner.TestReport

--- a/tests/guinea-pigs/pytest/custom/conftest.py
+++ b/tests/guinea-pigs/pytest/custom/conftest.py
@@ -1,13 +1,35 @@
 import pytest
 
-def pytest_collect_file(parent, path):
-    if path.ext == ".yml" and path.basename.startswith("test"):
-        return YamlFile.from_parent(parent, fspath=path)
+
+def _pytest_major_version():
+    return int(pytest.__version__.split('.', 1)[0])
+
+
+def _is_test_yaml_file(path):
+    if hasattr(path, "suffix"):
+        return path.suffix == ".yml" and path.name.startswith("test")
+    return path.ext == ".yml" and path.basename.startswith("test")
+
+
+def _node_path(node):
+    if hasattr(node, "path"):
+        return node.path
+    return node.fspath
+
+
+if _pytest_major_version() >= 7:
+    def pytest_collect_file(parent, file_path):
+        if _is_test_yaml_file(file_path):
+            return YamlFile.from_parent(parent, path=file_path)
+else:
+    def pytest_collect_file(parent, path):
+        if _is_test_yaml_file(path):
+            return YamlFile.from_parent(parent, fspath=path)
 
 
 class YamlFile(pytest.File):
     def collect(self):
-        f = self.fspath.open()
+        f = _node_path(self).open()
         for line in f.readlines():
             yield YamlItem.from_parent(self, name=line.strip(), spec="xxx")
         f.close()
@@ -21,4 +43,4 @@ class YamlItem(pytest.Item):
         pass
 
     def reportinfo(self):
-        return self.fspath, 0, "usecase: %s" % self.name
+        return _node_path(self), 0, "usecase: %s" % self.name

--- a/tests/guinea-pigs/pytest/logging_output_test.py
+++ b/tests/guinea-pigs/pytest/logging_output_test.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def test_log_on_failure():
+    logging.warning("pytest log warning")
+    assert False
+
+
+def test_log_on_success():
+    logging.warning("pytest log warning")

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import platform
+import subprocess
 import sys
 
 import pytest
@@ -39,10 +40,20 @@ def fix_slashes(s):
 @contextlib.contextmanager
 def make_ini(content):
     path = os.path.join(get_teamcity_messages_root(), 'pytest.ini')
-    with open(path, 'w+') as f:
-        f.write(content)
-    yield
-    os.remove(path)
+    previous_content = None
+    if os.path.exists(path):
+        with open(path) as f:
+            previous_content = f.read()
+    try:
+        with open(path, 'w+') as f:
+            f.write(content)
+        yield
+    finally:
+        if previous_content is None:
+            os.remove(path)
+        else:
+            with open(path, 'w+') as f:
+                f.write(previous_content)
 
 
 # disable pytest-pep8 on 3.4 due to "No such file or directory: 'doc'" issue
@@ -131,7 +142,19 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
                 ServiceMessage('testFailed', {'name': test_name, 'message': test_message}),
                 ServiceMessage('testFinished', {'name': test_name}),
             ])
-        ms = assert_service_messages(output, expected)
+        seen_flake8_messages = set()
+
+        def first_flake8_message_occurrence(message):
+            message_name = message.params.get('name', '')
+            if not message_name.startswith('pep8: '):
+                return True
+            message_key = (message.name, message_name)
+            if message_key in seen_flake8_messages:
+                return False
+            seen_flake8_messages.add(message_key)
+            return True
+
+        ms = assert_service_messages(output, expected, actual_messages_predicate=first_flake8_message_occurrence)
         assert ms[2].params["details"].find(test_message.replace('|', '|||')) > 0
 
 
@@ -301,6 +324,7 @@ def test_output(venv):
             ServiceMessage('testStdErr', {'name': test_name, 'flowId': test_name, 'out': 'teardown stderr|n'}),
             ServiceMessage('blockClosed', {'name': 'test teardown'}),
         ])
+    assert "[100%]\n##teamcity[testStdOut" in output
 
 
 def test_class_with_method(venv):
@@ -350,6 +374,83 @@ def test_output_no_capture(venv):
     assert "test stdout" in output
     assert "teardown stderr" in output
     assert "teardown stdout" in output
+
+
+def test_logging_output_ignored_for_failed_test_by_default(venv):
+    output = run(venv, 'logging_output_test.py', test='test_log_on_failure')
+
+    test_name = 'tests.guinea-pigs.pytest.logging_output_test.test_log_on_failure'
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFailed', {'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+    assert "##teamcity[testStdOut" not in output
+    assert "##teamcity[testLog" not in output
+
+
+def test_logging_output_reported_as_test_log_with_programmatic_switch(venv):
+    output = run_with_programmatic_options(venv, 'logging_output_test.py', test='test_log_on_failure', report_logs_as_test_log=True)
+
+    test_name = 'tests.guinea-pigs.pytest.logging_output_test.test_log_on_failure'
+    messages = assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testLog', {'flowId': test_name}),
+            ServiceMessage('testFailed', {'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+
+    assert "pytest log warning" in messages[2].params["out"]
+    assert "##teamcity[testStdOut" not in output
+
+
+def test_logging_output_ignored_for_passed_test_by_default(venv):
+    output = run(venv, 'logging_output_test.py', test='test_log_on_success')
+
+    test_name = 'tests.guinea-pigs.pytest.logging_output_test.test_log_on_success'
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+    assert "pytest log warning" not in output
+
+
+def test_logging_output_skipped_for_passed_test_with_programmatic_default(venv):
+    output = run_with_programmatic_options(venv, 'logging_output_test.py', test='test_log_on_success', skip_passed_output=True)
+
+    test_name = 'tests.guinea-pigs.pytest.logging_output_test.test_log_on_success'
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+    assert "pytest log warning" not in output
+
+
+def test_logging_output_ignored_for_passed_test_when_ini_overrides_programmatic_default(venv):
+    with make_ini('[pytest]\nskippassedoutput=false'):
+        output = run_with_programmatic_options(venv, 'logging_output_test.py', test='test_log_on_success', skip_passed_output=True)
+
+    test_name = 'tests.guinea-pigs.pytest.logging_output_test.test_log_on_success'
+    assert_service_messages(
+        output,
+        [
+            ServiceMessage('testCount', {'count': "1"}),
+            ServiceMessage('testStarted', {'name': test_name, 'flowId': test_name}),
+            ServiceMessage('testFinished', {'name': test_name, 'flowId': test_name}),
+        ])
+    assert "pytest log warning" not in output
 
 
 def test_teardown_error(venv):
@@ -667,3 +768,29 @@ def run(venv, file_names, test=None, options='', set_tc_version=True, additional
     if additional_arguments:
         command += " " + additional_arguments
     return run_command(command, set_tc_version=set_tc_version, env=env)
+
+
+def run_with_programmatic_options(venv, file_names, test=None, skip_passed_output=False, report_logs_as_test_log=False):
+    if test is not None:
+        test_suffix = "::" + test
+    else:
+        test_suffix = ""
+
+    if not isinstance(file_names, list):
+        file_names = [file_names]
+
+    pytest_args = [
+        os.path.join('tests', 'guinea-pigs', 'pytest', file_name) + test_suffix
+        for file_name in file_names
+    ]
+    code = (
+        "import pytest, sys;"
+        "from teamcity import pytest_plugin;"
+        "pytest_plugin.set_skip_passed_output_default(%r);"
+        "pytest_plugin.set_report_logs_as_test_log(%r);"
+        "sys.exit(pytest.main(%r, plugins=[pytest_plugin]))"
+    ) % (skip_passed_output, report_logs_as_test_log, pytest_args)
+    command = subprocess.list2cmdline([os.path.join(venv.bin, 'python'), '-c', code])
+    env = virtual_environments.get_clean_system_environment()
+    env['PYTEST_DISABLE_PLUGIN_AUTOLOAD'] = '1'
+    return run_command(command, env=env)

--- a/tests/unit-tests/messages_test.py
+++ b/tests/unit-tests/messages_test.py
@@ -202,6 +202,15 @@ def test_test_stdout():
         """).strip().encode('utf-8')
 
 
+def test_test_log():
+    stream = StreamStub()
+    messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)
+    messages.message('testLog', name='only a test', out='out')
+    assert stream.observed_output.strip() == textwrap.dedent("""\
+        ##teamcity[testLog timestamp='2000-11-02T10:23:01.556' name='only a test' out='out']
+        """).strip().encode('utf-8')
+
+
 def test_test_stderr():
     stream = StreamStub()
     messages = TeamcityServiceMessages(output=stream, now=lambda: fixed_date)


### PR DESCRIPTION
## Summary

This ports the pytest captured-output fixes needed by the PyCharm helper copy back to `teamcity-messages`, while preserving the standalone reporter's existing defaults.

The change solves two related reporting issues:

- Captured output service messages could be written on the same line as pytest progress text. For example:

```text
PASSED                 [100%]##teamcity[testStdOut ...]
```

  The reporter keeps captured-output service messages separated from pytest progress output so they remain parseable.
- Pytest captured log sections should not be dumped to `testStdOut`. By default, the TeamCity pytest reporter now ignores captured log sections. Embedding runners can opt in programmatically and receive those sections as generic `testLog` service messages with `name`, `out`, and `flowId`.

## Details

This PR intentionally does **not** change the default for `skippassedoutput` in `teamcity-messages`: standalone TeamCity reporting continues to include captured stdout/stderr from passed tests unless users opt out with `skippassedoutput=true`.

Embedded runners that need a different UI default can call `teamcity.pytest_plugin.set_skip_passed_output_default(True)` before pytest registers plugin options. That value is only the ini default; an explicit project setting such as `skippassedoutput=false` still overrides it.

Captured logs use a separate opt-in switch, `teamcity.pytest_plugin.set_report_logs_as_test_log(True)`. The emitted message is generic:

```text
##teamcity[testLog name='...' out='...' flowId='...']
```

It deliberately does not include a log level because pytest log formatting is configurable and the level cannot be recovered reliably from the rendered section text.

The temporary `pytest.ini` helper restores the original project config after each test, so test runs do not leave committed files modified.

## Test Plan

- `uv run --python 3.11 --with pytest==9.0.3 --with virtualenv==20.16.5 python -m pytest tests/integration-tests/pytest_integration_test.py`
  - `42 passed, 2 skipped`
- `PYTHONPATH="teamcity:..." python3 -m pytest tests/integration-tests/pytest_integration_test.py`
  - local Python 3.9.6 / pytest 8.4.2 harness
  - `42 passed, 2 skipped`
- temporary uv matrix for changed pytest cases, with inner venvs pinned to `pytest==6.2.5`, `pytest==7.4.4`, `pytest==8.4.2`, and `pytest==9.0.3`
  - covered custom collection, flake8 service-message parsing, captured-log defaults, `testLog` opt-in, and `skippassedoutput`
  - `32 passed`
- `uv run --python 3.11 --with pytest==9.0.3 python -m pytest tests/unit-tests tests/unit-tests-since-2.6`
  - `48 passed`
